### PR TITLE
Fix release workflow: use RELEASE_TOKEN for branch protection bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
## Summary

- Replace `secrets.GITHUB_TOKEN` with `secrets.RELEASE_TOKEN` (PAT) in the release workflow checkout step
- `GITHUB_TOKEN` cannot push to protected branches with required status checks, causing the version bump commit to fail

## Test plan

- [ ] Verify `RELEASE_TOKEN` secret is set in repo settings
- [ ] Merge this PR and confirm the release workflow completes successfully
- [ ] Confirm version bump commit is pushed to main

Closes #6