### PR TITLE
Skip CodeQL on version-only changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,12 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - pyproject.toml
   pull_request:
     branches: [main]
+    paths-ignore:
+      - pyproject.toml
 
 jobs:
   analyze:

--- a/src/improve/cli.py
+++ b/src/improve/cli.py
@@ -11,7 +11,7 @@ from improve.loop import IterationLoop
 from improve.process import require_tools
 from improve.prompt import AVAILABLE_PHASES
 from improve.state import LOG_FILE, STATE_DIR, LoopState
-from improve.version import check_for_update
+from improve.version import check_for_update, get_installed_version
 
 logger = logging.getLogger("improve")
 
@@ -130,7 +130,7 @@ def main() -> None:
     mode = "parallel" if args.parallel else ("batch" if args.batch else "sequential")
     header = (
         f"\n{'=' * 50}\n"
-        f"  Iterative Improvement Loop\n"
+        f"  Iterative Improvement Loop v{get_installed_version()}\n"
         f"  Branch:     {current_branch}\n"
         f"  Iterations: {start_iteration}-{args.iterations}\n"
         f"  Phases:     {', '.join(phases)}\n"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "iterative-improve"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Add `paths-ignore: pyproject.toml` to CodeQL workflow so it doesn't run on version bump commits that only touch `pyproject.toml`

## Test plan
- [ ] Merge a version bump and verify CodeQL workflow is not triggered
- [ ] Push a code change and verify CodeQL still runs