### PR TITLE
Fix incorrect glab CLI flags for GitLab CI detection

### DIFF
--- a/src/improve/ci_gitlab.py
+++ b/src/improve/ci_gitlab.py
@@ -20,25 +20,25 @@ _STATUS_MAP = {
 
 class GitLabCI:
     def get_latest_run_id(self, branch: str) -> int | None:
-        result = run(["glab", "ci", "list", "--branch", branch, "--per-page", "1", "-o", "json"])
+        result = run(["glab", "ci", "list", "--ref", branch, "--per-page", "1", "-F", "json"])
         if result.returncode != 0:
             return None
         try:
             pipelines = json.loads(result.stdout)
             return pipelines[0]["id"] if pipelines else None
         except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
-            logger.debug("ci-gitlab] Failed to parse pipeline list: %s", exc)
+            logger.debug("[ci-gitlab] Failed to parse pipeline list: %s", exc)
             return None
 
     def get_run_conclusion(self, run_id: int) -> str | None:
-        result = run(["glab", "ci", "view", str(run_id), "-o", "json"])
+        result = run(["glab", "ci", "get", "-p", str(run_id), "-F", "json"])
         if result.returncode != 0:
             return None
         try:
             status = json.loads(result.stdout).get("status")
             return _STATUS_MAP.get(status)
-        except (json.JSONDecodeError, AttributeError) as exc:
-            logger.debug("ci-gitlab] Failed to parse pipeline status: %s", exc)
+        except (json.JSONDecodeError, AttributeError, TypeError) as exc:
+            logger.debug("[ci-gitlab] Failed to parse pipeline status: %s", exc)
             return None
 
     def watch_run(self, run_id: int, timeout: int) -> bool:
@@ -50,9 +50,33 @@ class GitLabCI:
             if conclusion is not None:
                 return False
             time.sleep(POLL_INTERVAL)
-        logger.warning("ci-gitlab] Pipeline %d timed out after %ds", run_id, timeout)
+        logger.warning("[ci-gitlab] Pipeline %d timed out after %ds", run_id, timeout)
         return False
 
     def get_failed_logs(self, run_id: int) -> str:
-        result = run(["glab", "ci", "view", str(run_id), "--log"], timeout=60)
-        return result.stdout[-4000:] if result.stdout else "No logs available"
+        detail = run(["glab", "ci", "get", "-p", str(run_id), "-d", "-F", "json"], timeout=60)
+        if detail.returncode != 0 or not detail.stdout:
+            return "No logs available"
+
+        failed_job_ids = self._extract_failed_job_ids(detail.stdout)
+        if not failed_job_ids:
+            return "No failed jobs found"
+
+        logs: list[str] = []
+        for job_id in failed_job_ids:
+            trace = run(["glab", "ci", "trace", str(job_id)], timeout=60)
+            if trace.returncode == 0 and trace.stdout:
+                logs.append(trace.stdout)
+
+        combined = "\n".join(logs) if logs else "No logs available"
+        return combined[-4000:]
+
+    @staticmethod
+    def _extract_failed_job_ids(stdout: str) -> list[int]:
+        try:
+            data = json.loads(stdout)
+            jobs = data.get("jobs", [])
+            return [j["id"] for j in jobs if j.get("status") == "failed"]
+        except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as exc:
+            logger.debug("[ci-gitlab] Failed to extract failed job IDs: %s", exc)
+            return []

--- a/tests/test_ci_gitlab.py
+++ b/tests/test_ci_gitlab.py
@@ -34,7 +34,7 @@ class TestGetLatestRunId:
             provider.get_latest_run_id("my-branch")
 
         mock_run.assert_called_once_with(
-            ["glab", "ci", "list", "--branch", "my-branch", "--per-page", "1", "-o", "json"]
+            ["glab", "ci", "list", "--ref", "my-branch", "--per-page", "1", "-F", "json"]
         )
 
 
@@ -71,6 +71,13 @@ class TestGetRunConclusion:
         with patch("improve.ci_gitlab.run", return_value=_cp(stdout="bad")):
             assert provider.get_run_conclusion(1) is None
 
+    def test_returns_none_when_status_is_unhashable(self, provider):
+        with patch(
+            "improve.ci_gitlab.run",
+            return_value=_cp(stdout=json.dumps({"status": ["not", "a", "string"]})),
+        ):
+            assert provider.get_run_conclusion(1) is None
+
 
 class TestWatchRun:
     @pytest.mark.parametrize(
@@ -102,16 +109,75 @@ class TestWatchRun:
 
 
 class TestGetFailedLogs:
-    def test_returns_log_output(self, provider):
-        with patch("improve.ci_gitlab.run", return_value=_cp(stdout="error details")):
+    def _pipeline_json(self, jobs: list[dict]) -> str:
+        return json.dumps({"jobs": jobs})
+
+    def test_returns_log_output_for_failed_jobs(self, provider):
+        pipeline = self._pipeline_json([{"id": 10, "status": "failed"}])
+        with patch(
+            "improve.ci_gitlab.run",
+            side_effect=[
+                _cp(stdout=pipeline),
+                _cp(stdout="error details"),
+            ],
+        ):
             assert provider.get_failed_logs(1) == "error details"
 
+    def test_concatenates_logs_from_multiple_failed_jobs(self, provider):
+        pipeline = self._pipeline_json(
+            [
+                {"id": 10, "status": "failed"},
+                {"id": 11, "status": "failed"},
+            ]
+        )
+        with patch(
+            "improve.ci_gitlab.run",
+            side_effect=[
+                _cp(stdout=pipeline),
+                _cp(stdout="log A"),
+                _cp(stdout="log B"),
+            ],
+        ):
+            assert provider.get_failed_logs(1) == "log A\nlog B"
+
+    def test_skips_successful_jobs(self, provider):
+        pipeline = self._pipeline_json(
+            [
+                {"id": 10, "status": "success"},
+                {"id": 11, "status": "failed"},
+            ]
+        )
+        with patch(
+            "improve.ci_gitlab.run",
+            side_effect=[
+                _cp(stdout=pipeline),
+                _cp(stdout="only failure"),
+            ],
+        ):
+            assert provider.get_failed_logs(1) == "only failure"
+
     def test_truncates_long_output(self, provider):
-        with patch("improve.ci_gitlab.run", return_value=_cp(stdout="x" * 5000)):
+        pipeline = self._pipeline_json([{"id": 10, "status": "failed"}])
+        with patch(
+            "improve.ci_gitlab.run",
+            side_effect=[
+                _cp(stdout=pipeline),
+                _cp(stdout="x" * 5000),
+            ],
+        ):
             result = provider.get_failed_logs(1)
 
         assert len(result) == 4000
 
-    def test_returns_fallback_when_empty(self, provider):
-        with patch("improve.ci_gitlab.run", return_value=_cp(stdout="")):
+    def test_returns_fallback_when_pipeline_command_fails(self, provider):
+        with patch("improve.ci_gitlab.run", return_value=_cp(returncode=1)):
             assert provider.get_failed_logs(1) == "No logs available"
+
+    def test_returns_fallback_when_no_failed_jobs(self, provider):
+        pipeline = self._pipeline_json([{"id": 10, "status": "success"}])
+        with patch("improve.ci_gitlab.run", return_value=_cp(stdout=pipeline)):
+            assert provider.get_failed_logs(1) == "No failed jobs found"
+
+    def test_returns_fallback_when_jobs_payload_is_non_dict(self, provider):
+        with patch("improve.ci_gitlab.run", return_value=_cp(stdout="[1, 2, 3]")):
+            assert provider.get_failed_logs(1) == "No failed jobs found"

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "iterative-improve"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Replace `--branch` with `--ref` and `-o` with `-F` in `get_latest_run_id` to match actual `glab ci list` flags
- Replace `glab ci view` with `glab ci get -p` in `get_run_conclusion` for proper JSON pipeline status
- Rewrite `get_failed_logs` to use two-step approach: fetch pipeline details with `glab ci get -p -d`, then trace each failed job with `glab ci trace`

## Test plan
- [x] All 385 existing tests pass
- [x] Updated tests verify correct glab CLI flags are passed
- [x] New tests cover multi-job log concatenation, job filtering, and error fallbacks
- [x] 93% code coverage maintained
- [ ] Manual: run `iterative-improve` on GitLab project to confirm CI pipeline detection works