### PR TITLE
Skip CI jobs on version bump commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   lint:
+    if: "!startsWith(github.event.head_commit.message, 'Bump version')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -23,6 +24,7 @@ jobs:
         run: uv run ruff format --check src/ tests/
 
   test:
+    if: "!startsWith(github.event.head_commit.message, 'Bump version')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -46,6 +48,7 @@ jobs:
           path: coverage.xml
 
   mutation:
+    if: "!startsWith(github.event.head_commit.message, 'Bump version')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Skip lint, test, and mutation jobs when the commit message starts with "Bump version"
- Saves CI minutes on commits that only change the version number

## Test plan
- [ ] Push a commit with message starting with "Bump version" and verify CI jobs are skipped
- [ ] Push a regular commit and verify CI jobs still run