### PR TITLE
Add revert-on-fail, crash recovery, phase timeout, continuous mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,16 @@ CLI tool that runs iterative code improvement loops on feature branches using Cl
 uv tool install .
 
 # Run the tool (must be on a feature branch, not main/master)
-iterative-improve -n 5
-iterative-improve -n 5 --batch              # all phases then CI once (faster)
-iterative-improve -n 5 --parallel           # phases in parallel via git worktrees (fastest)
-iterative-improve -n 5 --resume             # resume after interruption
-iterative-improve -n 3 --skip-ci            # skip CI checks
-iterative-improve -n 5 --phases simplify,review  # specific phases only
-iterative-improve -n 5 --squash             # squash commits when done
+iterative-improve                           # runs continuously until convergence
+iterative-improve -n 5                      # cap at 5 iterations
+iterative-improve --batch                   # all phases then CI once (faster)
+iterative-improve --parallel                # phases in parallel via git worktrees (fastest)
+iterative-improve --resume                  # resume after interruption
+iterative-improve --skip-ci                 # skip CI checks
+iterative-improve --phases simplify,review  # specific phases only
+iterative-improve --squash                  # squash commits when done
+iterative-improve --revert-on-fail          # revert bad changes, keep going
+iterative-improve --phase-timeout 300       # Claude subprocess timeout (default: 900s)
 
 # Lint
 uv run ruff check src/ tests/
@@ -53,8 +56,12 @@ All source is in `src/improve/`. Entry point: `improve.cli:main`.
 - External tools required at runtime: `git`, `claude` (Claude Code CLI), `gh` (GitHub CLI)
 - State persists to `.improve-loop/` directory (state.json + run.log)
 - Three phases available: `simplify`, `review`, `security` — configurable via `--phases`
-- Claude subprocess timeout: 900s. CI run timeout: configurable via `--ci-timeout` (default 15 min)
+- Runs continuously by default (until convergence); use `-n` to cap iterations
+- Claude subprocess timeout: configurable via `--phase-timeout` (default 900s)
+- CI run timeout: configurable via `--ci-timeout` (default 15 min)
 - CI fix retries capped at 5 attempts per phase
+- `--revert-on-fail` reverts changes that fail CI (`git reset --hard` + force push) and continues
+- Crash recovery: phase exceptions are caught, working tree is cleaned, loop continues
 - `--batch` and `--parallel` are mutually exclusive (argparse enforced)
 - `--parallel` runs all phases concurrently in git worktrees, merges changes, single commit+push
 - `--squash` squashes all branch commits into one via `git reset --soft` + force push

--- a/src/improve/claude.py
+++ b/src/improve/claude.py
@@ -15,6 +15,12 @@ logger = logging.getLogger("improve")
 
 CLAUDE_TIMEOUT = 900
 
+
+def set_timeout(seconds: int) -> None:
+    global CLAUDE_TIMEOUT
+    CLAUDE_TIMEOUT = seconds
+
+
 _active_processes: set[subprocess.Popen] = set()
 _process_lock = threading.RLock()
 

--- a/src/improve/cli.py
+++ b/src/improve/cli.py
@@ -6,7 +6,7 @@ import sys
 import threading
 from datetime import datetime
 
-from improve import ci, git
+from improve import ci, claude, git
 from improve.ci_gitlab import GitLabCI
 from improve.loop import IterationLoop
 from improve.preflight import run_preflight
@@ -40,7 +40,9 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Iterative code improvement loop using Claude and CI"
     )
-    parser.add_argument("-n", "--iterations", type=int, default=10)
+    parser.add_argument(
+        "-n", "--iterations", type=int, default=None, help="Max iterations (omit for continuous)"
+    )
     parser.add_argument("--ci-timeout", type=int, default=15, help="CI timeout in minutes")
     parser.add_argument("--skip-ci", action="store_true")
     mode_group = parser.add_mutually_exclusive_group()
@@ -71,6 +73,17 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         help="CI provider (default: auto-detect from git remote)",
     )
+    parser.add_argument(
+        "--revert-on-fail",
+        action="store_true",
+        help="Revert changes that fail CI instead of stopping",
+    )
+    parser.add_argument(
+        "--phase-timeout",
+        type=int,
+        default=900,
+        help="Phase timeout in seconds (default: %(default)s)",
+    )
     return parser.parse_args()
 
 
@@ -100,13 +113,17 @@ def main() -> None:
     ci_tool = "glab" if platform == "gitlab" else "gh"
     require_tools(ci_tool)
 
-    if args.iterations < 1:
+    if args.iterations is not None and args.iterations < 1:
         logger.error("loop] Iterations must be at least 1")
         sys.exit(1)
     if args.ci_timeout < 1:
         logger.error("loop] CI timeout must be at least 1 minute")
         sys.exit(1)
+    if args.phase_timeout < 30:
+        logger.error("loop] Phase timeout must be at least 30 seconds")
+        sys.exit(1)
     ci.set_timeout(args.ci_timeout)
+    claude.set_timeout(args.phase_timeout)
     phases = _validate_phases(args.phases)
 
     current_branch = git.branch()
@@ -123,6 +140,8 @@ def main() -> None:
 
     run_preflight(current_branch, ci_tool, args.skip_ci)
 
+    continuous = args.iterations is None
+    max_iterations = 1000 if continuous else args.iterations
     start_iteration = 1
     state = LoopState(branch=current_branch, started_at=datetime.now().isoformat())
     if args.resume:
@@ -145,35 +164,38 @@ def main() -> None:
         phases=phases,
         squash=args.squash,
         parallel=args.parallel,
+        revert_on_fail=args.revert_on_fail,
+        continuous=continuous,
     )
     loop.install_signal_handlers()
 
     mode = "parallel" if args.parallel else ("batch" if args.batch else "sequential")
+    iter_display = "continuous" if continuous else f"{start_iteration}-{max_iterations}"
     header = (
         f"\n{'=' * 50}\n"
         f"  Iterative Improvement Loop v{get_installed_version()}\n"
         f"  Branch:     {current_branch}\n"
-        f"  Iterations: {start_iteration}-{args.iterations}\n"
+        f"  Iterations: {iter_display}\n"
         f"  Phases:     {', '.join(phases)}\n"
         f"  Mode:       {mode}\n"
         f"  CI:         {'skip' if args.skip_ci else f'{args.ci_timeout}m timeout'}\n"
+        f"  Revert:     {'yes' if args.revert_on_fail else 'no'}\n"
         f"  Squash:     {'yes' if args.squash else 'no'}\n"
         f"{'=' * 50}"
     )
     print(header)
     logger.info(
-        "loop] Started: branch=%s iterations=%d-%d phases=%s mode=%s skip_ci=%s squash=%s",
+        "loop] Started: branch=%s iterations=%s phases=%s mode=%s skip_ci=%s revert=%s",
         current_branch,
-        start_iteration,
-        args.iterations,
+        iter_display,
         ",".join(phases),
         mode,
         args.skip_ci,
-        args.squash,
+        args.revert_on_fail,
     )
 
     if not git.sync_with_main(current_branch):
         logger.error("loop] Cannot sync with main, aborting")
         sys.exit(1)
 
-    loop.run(start_iteration, args.iterations)
+    loop.run(start_iteration, max_iterations)

--- a/src/improve/git.py
+++ b/src/improve/git.py
@@ -11,6 +11,27 @@ from improve.prompt import build_conflict_prompt, extract_summary
 logger = logging.getLogger("improve")
 
 
+def head_sha() -> str:
+    return run(["git", "rev-parse", "HEAD"]).stdout.strip()
+
+
+def revert_to(sha: str, branch_name: str) -> bool:
+    reset = run(["git", "reset", "--hard", sha])
+    if reset.returncode != 0:
+        logger.warning("git] Reset failed: %s", reset.stderr.strip())
+        return False
+    push = run(["git", "push", "--force-with-lease", "origin", branch_name])
+    if push.returncode != 0:
+        logger.warning("git] Force push failed: %s", push.stderr.strip())
+        return False
+    logger.info("git] Reverted to %s", sha[:8])
+    return True
+
+
+def discard_changes() -> None:
+    run(["git", "checkout", "--", "."])
+
+
 def branch() -> str:
     return run(["git", "branch", "--show-current"]).stdout.strip()
 
@@ -197,6 +218,7 @@ def apply_worktree_changes(worktree_path: str) -> list[str]:
     main_root = run(["git", "rev-parse", "--show-toplevel"]).stdout.strip()
     worktree = Path(worktree_path).resolve()
     main = Path(main_root).resolve()
+    applied: list[str] = []
     for f in files:
         src = (worktree / f).resolve()
         dst = (main / f).resolve()
@@ -208,7 +230,8 @@ def apply_worktree_changes(worktree_path: str) -> list[str]:
             shutil.copy2(src, dst)
         elif dst.exists():
             dst.unlink()
-    return files
+        applied.append(f)
+    return applied
 
 
 def squash_branch(branch_name: str, message: str) -> bool:

--- a/src/improve/loop.py
+++ b/src/improve/loop.py
@@ -4,6 +4,7 @@ import logging
 import signal
 import sys
 import time
+from dataclasses import replace
 
 from improve import ci, claude, git
 from improve.parallel import run_parallel_batch
@@ -14,7 +15,7 @@ from improve.prompt import (
     build_phase_prompt,
     extract_summary,
 )
-from improve.state import LOG_FILE, STATE_FILE, LoopState, PhaseResult
+from improve.state import LoopState, PhaseResult, format_summary
 
 logger = logging.getLogger("improve")
 
@@ -30,12 +31,16 @@ class IterationLoop:
         phases: list[str],
         squash: bool = False,
         parallel: bool = False,
+        revert_on_fail: bool = False,
+        continuous: bool = False,
     ):
         self.state = state
         self.skip_ci = skip_ci
         self.batch = batch
         self.squash = squash
         self.parallel = parallel
+        self.revert_on_fail = revert_on_fail
+        self.continuous = continuous
         self.loop_start: float = 0.0
         self._active_phases: list[str] = list(phases)
 
@@ -45,16 +50,18 @@ class IterationLoop:
 
     def shutdown(self, signum: int, _frame: object) -> None:
         logger.info("signal] Caught %s, shutting down...", signal.Signals(signum).name)
-        claude.terminate_active()
+        try:
+            claude.terminate_active()
+        except Exception:
+            logger.warning("signal] Failed to terminate Claude processes", exc_info=True)
         try:
             self.state.save()
         except Exception:
-            logger.warning("signal] Failed to save state during shutdown")
-        elapsed = time.monotonic() - self.loop_start if self.loop_start else 0
+            logger.warning("signal] Failed to save state during shutdown", exc_info=True)
         try:
-            self.print_summary(elapsed)
+            self.print_summary(time.monotonic() - self.loop_start if self.loop_start else 0)
         except Exception:
-            logger.warning("signal] Failed to print summary during shutdown")
+            logger.warning("signal] Failed to print summary during shutdown", exc_info=True)
         sys.exit(130)
 
     def retry_ci_fixes(
@@ -79,44 +86,31 @@ class IterationLoop:
                 self.state.branch, known_previous_id=pre_push_id
             )
             total_ci += ci_time
+        if not ci_passed and retries >= MAX_CI_RETRIES:
+            logger.warning("ci-fix] All %d attempts exhausted, CI still failing", MAX_CI_RETRIES)
         return ci_passed, retries, total_claude, total_ci
 
     def run_phase(self, phase: str, iteration: int, skip_ci: bool) -> PhaseResult:
         phase_start = time.monotonic()
         prompt = build_phase_prompt(phase, git.diff_vs_main(), self.state.context())
-
         logger.info("%s] Running...", phase)
         output, total_claude = claude.run_claude(prompt)
-
         files = git.changed_files()
         if not files:
             logger.info("%s] No changes", phase)
             elapsed = time.monotonic() - phase_start
-            return PhaseResult(
-                iteration=iteration,
-                phase=phase,
-                changes_made=False,
-                files=[],
-                summary="No changes needed",
-                ci_passed=True,
-                ci_retries=0,
-                duration_seconds=elapsed,
-                claude_seconds=total_claude,
-            )
+            return PhaseResult.no_changes(iteration, phase, elapsed, total_claude)
         summary = extract_summary(output)
         logger.info("%s] Changed %d file(s): %s", phase, len(files), ", ".join(files[:5]))
 
         pre_push_id = ci.get_latest_run_id(self.state.branch) if not skip_ci else None
         pushed = git.commit_and_push(build_commit_message(phase, summary), self.state.branch)
-        ci_passed = pushed
-        total_ci = 0.0
-        retries = 0
+        ci_passed, total_ci, retries = pushed, 0.0, 0
 
         if pushed and not skip_ci:
-            ci_passed, ci_errors, ci_time = ci.wait_for_ci(
+            ci_passed, ci_errors, total_ci = ci.wait_for_ci(
                 self.state.branch, known_previous_id=pre_push_id
             )
-            total_ci = ci_time
             ci_passed, retries, fix_claude, fix_ci = self.retry_ci_fixes(
                 ci_passed, ci_errors, f"Fix CI after {phase}"
             )
@@ -124,12 +118,10 @@ class IterationLoop:
             total_ci += fix_ci
 
         elapsed = time.monotonic() - phase_start
-        duration = format_duration(elapsed)
+        dur = format_duration(elapsed)
         if total_ci > 0:
-            claude_dur = format_duration(total_claude)
-            ci_dur = format_duration(total_ci)
-            duration += f" (claude: {claude_dur}, ci: {ci_dur})"
-        logger.info("%s] Phase done in %s", phase, duration)
+            dur += f" (claude: {format_duration(total_claude)}, ci: {format_duration(total_ci)})"
+        logger.info("%s] Phase done in %s", phase, dur)
         return PhaseResult(
             iteration=iteration,
             phase=phase,
@@ -143,42 +135,24 @@ class IterationLoop:
             ci_seconds=total_ci,
         )
 
+    def _run_phase_safe(self, phase: str, iteration: int, skip_ci: bool) -> PhaseResult:
+        try:
+            return self.run_phase(phase, iteration, skip_ci)
+        except Exception:
+            logger.exception("loop] Phase %s crashed, skipping", phase)
+            try:
+                git.discard_changes()
+            except Exception:
+                logger.warning("loop] Failed to discard changes after crash", exc_info=True)
+            return PhaseResult.crashed(iteration, phase)
+
     def print_summary(self, total_elapsed: float) -> None:
-        total_changed = sum(1 for r in self.state.results if r["changes_made"])
-        total_ci_fixes = sum(r["ci_retries"] for r in self.state.results)
-        total_claude_time = sum(r.get("claude_seconds", 0) for r in self.state.results)
-        total_ci_time = sum(r.get("ci_seconds", 0) for r in self.state.results)
-
-        overhead = format_duration(max(0, total_elapsed - total_claude_time - total_ci_time))
-        lines = [
-            f"\n{'=' * 60}",
-            "RESULTS",
-            f"{'=' * 60}",
-            f"  Phases run:     {len(self.state.results)}",
-            f"  With changes:   {total_changed}",
-            f"  CI fixes:       {total_ci_fixes}",
-            f"  Total time:     {format_duration(total_elapsed)}",
-            f"  Claude time:    {format_duration(total_claude_time)}",
-            f"  CI time:        {format_duration(total_ci_time)}",
-            f"  Overhead:       {overhead}",
-            "",
-        ]
-        for r in self.state.results:
-            marker = "+" if r["changes_made"] else " "
-            ci_status = "PASS" if r["ci_passed"] else "FAIL"
-            duration = format_duration(r.get("duration_seconds", 0))
-            lines.append(
-                f"  [{marker}] {r['phase']:10s} | CI:{ci_status} | {duration:>9s} | {r['summary']}"
-            )
-        lines.append(f"\n  State: {STATE_FILE}")
-        lines.append(f"  Log:   {LOG_FILE}")
-
-        summary = "\n".join(lines)
-        print(summary)
-        logger.debug(summary)
+        print(format_summary(self.state.results, total_elapsed))
 
     def _drop_converged_phases(self, results: list[PhaseResult]) -> None:
-        converged = {r.phase for r in results if not r.changes_made}
+        converged = {
+            r.phase for r in results if not r.changes_made and r.summary != "Phase crashed"
+        }
         if not converged:
             return
         self._active_phases = [p for p in self._active_phases if p not in converged]
@@ -188,11 +162,26 @@ class IterationLoop:
             ", ".join(self._active_phases) or "none",
         )
 
+    def _mark_recent_reverted(self, count: int) -> None:
+        for r in self.state.results[-count:]:
+            if r["changes_made"]:
+                r["reverted"] = True
+        self.state.save()
+
+    def _revert_batch(self, pre_sha: str, result_count: int) -> bool:
+        logger.info("loop] Reverting batch changes (CI failed)")
+        if not git.revert_to(pre_sha, self.state.branch):
+            logger.warning("loop] Revert failed, changes may be in inconsistent state")
+            return False
+        self._mark_recent_reverted(result_count)
+        return True
+
     def run_batch_iteration(self, iteration: int) -> bool:
+        pre_sha = git.head_sha() if self.revert_on_fail else ""
         pre_batch_run_id = ci.get_latest_run_id(self.state.branch) if not self.skip_ci else None
         results = []
         for phase in self._active_phases:
-            result = self.run_phase(phase, iteration, skip_ci=True)
+            result = self._run_phase_safe(phase, iteration, skip_ci=True)
             self.state.add(result)
             results.append(result)
 
@@ -201,7 +190,6 @@ class IterationLoop:
         if not any(r.changes_made for r in results):
             logger.info("loop] Converged: no changes in any phase")
             return False
-
         if not all(r.ci_passed for r in results):
             logger.warning("loop] Stopping: push failed")
             return False
@@ -213,11 +201,14 @@ class IterationLoop:
             )
             ci_passed, _, _, _ = self.retry_ci_fixes(ci_passed, ci_errors, "Fix CI")
             if not ci_passed:
+                if self.revert_on_fail and pre_sha:
+                    return self._revert_batch(pre_sha, len(results))
                 logger.warning("loop] Stopping: CI failed")
                 return False
         return True
 
     def run_parallel_batch_iteration(self, iteration: int) -> bool:
+        pre_sha = git.head_sha() if self.revert_on_fail else ""
         phase_results: list[PhaseResult] = []
 
         def _track_result(result: PhaseResult) -> None:
@@ -232,36 +223,48 @@ class IterationLoop:
             skip_ci=self.skip_ci,
             add_result=_track_result,
             retry_ci_fixes=self.retry_ci_fixes,
+            revert_sha=pre_sha,
         )
         if phase_results:
             self._drop_converged_phases(phase_results)
+        if pre_sha and result and git.head_sha() == pre_sha:
+            self._mark_recent_reverted(len(phase_results))
         return result
 
     def run_sequential_iteration(self, iteration: int) -> bool:
         results = []
         for phase in self._active_phases:
-            result = self.run_phase(phase, iteration, self.skip_ci)
+            pre_sha = git.head_sha() if self.revert_on_fail else ""
+            result = self._run_phase_safe(phase, iteration, self.skip_ci)
+
+            if not result.ci_passed and self.revert_on_fail and pre_sha:
+                logger.info("loop] Reverting %s changes (CI failed)", phase)
+                if git.revert_to(pre_sha, self.state.branch):
+                    result = replace(result, reverted=True)
+                else:
+                    logger.warning("loop] Revert failed for %s, stopping", phase)
+                    self.state.add(result)
+                    return False
+
             self.state.add(result)
             results.append(result)
 
-            if not result.ci_passed:
+            if not result.ci_passed and not self.revert_on_fail:
                 logger.warning("loop] Stopping: CI failed after %s", phase)
                 return False
 
         self._drop_converged_phases(results)
-
-        if not any(r.changes_made for r in results):
+        has_changes = any(r.changes_made for r in results)
+        if not has_changes:
             logger.info("loop] Converged: no changes in any phase")
-            return False
-
-        return True
+        return has_changes
 
     def _squash_branch(self) -> None:
-        summaries = [r["summary"] for r in self.state.results if r["changes_made"]]
-        if not summaries:
+        kept = self.state.kept_results()
+        if not kept:
             logger.info("loop] No changes to squash")
             return
-        message = "Improve code quality\n\n" + "\n".join(f"- {s}" for s in summaries)
+        message = "Improve code quality\n\n" + "\n".join(f"- {r['summary']}" for r in kept)
         if git.squash_branch(self.state.branch, message):
             logger.info("loop] Squashed all commits into one")
         else:
@@ -269,10 +272,10 @@ class IterationLoop:
 
     def run(self, start_iteration: int, max_iterations: int) -> None:
         self.loop_start = time.monotonic()
-
         for i in range(start_iteration, max_iterations + 1):
-            print(f"\n--- Iteration {i}/{max_iterations} ---")
-            logger.info("loop] === Iteration %d/%d ===", i, max_iterations)
+            label = str(i) if self.continuous else f"{i}/{max_iterations}"
+            print(f"\n--- Iteration {label} ---")
+            logger.info("loop] === Iteration %s ===", label)
             self.state.iteration = i
             self.state.save()
 
@@ -280,19 +283,18 @@ class IterationLoop:
                 logger.error("loop] Merge conflict could not be resolved, stopping")
                 break
 
-            if self.parallel:
-                should_continue = self.run_parallel_batch_iteration(i)
-            elif self.batch:
-                should_continue = self.run_batch_iteration(i)
-            else:
-                should_continue = self.run_sequential_iteration(i)
-
-            if not should_continue:
+            runner = (
+                self.run_parallel_batch_iteration
+                if self.parallel
+                else self.run_batch_iteration
+                if self.batch
+                else self.run_sequential_iteration
+            )
+            if not runner(i):
                 break
 
         total = time.monotonic() - self.loop_start
         logger.info("loop] Finished in %s", format_duration(total))
         self.print_summary(total)
-
         if self.squash:
             self._squash_branch()

--- a/src/improve/parallel.py
+++ b/src/improve/parallel.py
@@ -31,17 +31,7 @@ def run_phase_in_worktree(
     elapsed = time.monotonic() - phase_start
     if not files:
         logger.info("%s] No changes", phase)
-        return PhaseResult(
-            iteration=iteration,
-            phase=phase,
-            changes_made=False,
-            files=[],
-            summary="No changes needed",
-            ci_passed=True,
-            ci_retries=0,
-            duration_seconds=elapsed,
-            claude_seconds=total_claude,
-        )
+        return PhaseResult.no_changes(iteration, phase, elapsed, total_claude)
     summary = extract_summary(output)
     logger.info("%s] Changed %d file(s): %s", phase, len(files), ", ".join(files[:5]))
     logger.info("%s] Done in %s", phase, format_duration(elapsed))
@@ -58,15 +48,40 @@ def run_phase_in_worktree(
     )
 
 
-def _collect_results(futures: list[Future[PhaseResult]]) -> list[PhaseResult] | None:
+def _collect_results(
+    futures: list[Future[PhaseResult]], phases: list[str], iteration: int
+) -> list[PhaseResult]:
     results: list[PhaseResult] = []
-    for future in futures:
+    for phase, future in zip(phases, futures, strict=True):
         try:
             results.append(future.result())
         except Exception:
-            logger.exception("parallel] Phase execution failed")
-            return None
+            logger.exception("parallel] Phase %s crashed, skipping", phase)
+            results.append(PhaseResult.crashed(iteration, phase))
     return results
+
+
+def _check_ci_after_batch(
+    branch: str,
+    pre_batch_run_id: int | None,
+    retry_ci_fixes: Callable[..., tuple[bool, int, float, float]],
+    revert_sha: str,
+) -> bool:
+    ci_passed, ci_errors, _ci_time = ci.wait_for_ci(
+        branch,
+        known_previous_id=pre_batch_run_id,
+    )
+    ci_passed, _, _, _ = retry_ci_fixes(ci_passed, ci_errors, "Fix CI")
+    if ci_passed:
+        return True
+    if revert_sha:
+        logger.info("loop] Reverting parallel batch changes (CI failed)")
+        if not git.revert_to(revert_sha, branch):
+            logger.warning("loop] Revert failed, changes may be in inconsistent state")
+            return False
+        return True
+    logger.warning("loop] Stopping: CI failed")
+    return False
 
 
 def run_parallel_batch(
@@ -77,6 +92,7 @@ def run_parallel_batch(
     skip_ci: bool,
     add_result: Callable[[PhaseResult], None],
     retry_ci_fixes: Callable[..., tuple[bool, int, float, float]],
+    revert_sha: str = "",
 ) -> bool:
     branch_diff = git.diff_vs_main()
     pre_batch_run_id = ci.get_latest_run_id(branch) if not skip_ci else None
@@ -103,9 +119,7 @@ def run_parallel_batch(
                 )
                 for phase in phases
             ]
-            results = _collect_results(futures)
-        if results is None:
-            return False
+            results = _collect_results(futures, phases, iteration)
 
         seen_files: set[str] = set()
         for result in results:
@@ -118,8 +132,9 @@ def run_parallel_batch(
                     result.phase,
                     ", ".join(sorted(overlap)),
                 )
-            git.apply_worktree_changes(worktrees[result.phase])
-            seen_files.update(result.files)
+            applied = git.apply_worktree_changes(worktrees[result.phase])
+            result.files = applied
+            seen_files.update(applied)
 
         for result in results:
             add_result(result)
@@ -138,17 +153,9 @@ def run_parallel_batch(
             logger.warning("loop] Stopping: push failed")
             return False
 
-        if not skip_ci:
-            ci_passed, ci_errors, _ci_time = ci.wait_for_ci(
-                branch,
-                known_previous_id=pre_batch_run_id,
-            )
-            ci_passed, _, _, _ = retry_ci_fixes(ci_passed, ci_errors, "Fix CI")
-            if not ci_passed:
-                logger.warning("loop] Stopping: CI failed")
-                return False
-
-        return True
+        return skip_ci or _check_ci_after_batch(
+            branch, pre_batch_run_id, retry_ci_fixes, revert_sha
+        )
     finally:
         for path in worktrees.values():
             git.remove_worktree(path)

--- a/src/improve/state.py
+++ b/src/improve/state.py
@@ -5,6 +5,8 @@ import logging
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from improve.process import format_duration
+
 logger = logging.getLogger("improve")
 
 STATE_DIR = Path(".improve-loop")
@@ -24,6 +26,35 @@ class PhaseResult:
     duration_seconds: float = 0.0
     claude_seconds: float = 0.0
     ci_seconds: float = 0.0
+    reverted: bool = False
+
+    @classmethod
+    def no_changes(
+        cls, iteration: int, phase: str, duration: float = 0.0, claude_seconds: float = 0.0
+    ) -> PhaseResult:
+        return cls(
+            iteration=iteration,
+            phase=phase,
+            changes_made=False,
+            files=[],
+            summary="No changes needed",
+            ci_passed=True,
+            ci_retries=0,
+            duration_seconds=duration,
+            claude_seconds=claude_seconds,
+        )
+
+    @classmethod
+    def crashed(cls, iteration: int, phase: str) -> PhaseResult:
+        return cls(
+            iteration=iteration,
+            phase=phase,
+            changes_made=False,
+            files=[],
+            summary="Phase crashed",
+            ci_passed=True,
+            ci_retries=0,
+        )
 
 
 @dataclass
@@ -37,8 +68,11 @@ class LoopState:
         self.results.append(asdict(result))
         self.save()
 
+    def kept_results(self) -> list[dict]:
+        return [r for r in self.results if r["changes_made"] and not r.get("reverted")]
+
     def context(self) -> str:
-        changed = [r for r in self.results if r["changes_made"]]
+        changed = self.kept_results()
         if not changed:
             return "None (first iteration)"
         return "\n".join(f"- [{r['phase']}] {r['summary']}" for r in changed)
@@ -64,3 +98,37 @@ class LoopState:
         except (json.JSONDecodeError, KeyError, TypeError, OSError) as exc:
             logger.warning("state] Failed to load %s: %s", STATE_FILE, exc)
             return None
+
+
+def _ci_label(r: dict) -> str:
+    if r.get("reverted"):
+        return "REVT"
+    return "PASS" if r["ci_passed"] else "FAIL"
+
+
+def format_summary(results: list[dict], total_elapsed: float) -> str:
+    total_claude = sum(r.get("claude_seconds", 0) for r in results)
+    total_ci = sum(r.get("ci_seconds", 0) for r in results)
+    overhead = format_duration(max(0, total_elapsed - total_claude - total_ci))
+    lines = [
+        f"\n{'=' * 60}",
+        "RESULTS",
+        f"{'=' * 60}",
+        f"  Phases run:     {len(results)}",
+        f"  With changes:   {sum(1 for r in results if r['changes_made'])}",
+        f"  CI fixes:       {sum(r['ci_retries'] for r in results)}",
+        f"  Reverted:       {sum(1 for r in results if r.get('reverted'))}",
+        f"  Total time:     {format_duration(total_elapsed)}",
+        f"  Claude time:    {format_duration(total_claude)}",
+        f"  CI time:        {format_duration(total_ci)}",
+        f"  Overhead:       {overhead}",
+        "",
+    ]
+    for r in results:
+        marker = "+" if r["changes_made"] else " "
+        dur = format_duration(r.get("duration_seconds", 0))
+        lines.append(
+            f"  [{marker}] {r['phase']:10s} | CI:{_ci_label(r)} | {dur:>9s} | {r['summary']}"
+        )
+    lines.extend([f"\n  State: {STATE_FILE}", f"  Log:   {LOG_FILE}"])
+    return "\n".join(lines)

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -17,6 +17,7 @@ ALLOWED_IMPORTS = {
         "improve",
         "improve.ci",
         "improve.ci_gitlab",
+        "improve.claude",
         "improve.git",
         "improve.loop",
         "improve.preflight",
@@ -51,7 +52,7 @@ ALLOWED_IMPORTS = {
     "preflight": {"improve.process"},
     "process": set(),
     "prompt": set(),
-    "state": set(),
+    "state": {"improve.process"},
     "version": set(),
 }
 

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -18,7 +18,7 @@ class TestSetTimeout:
         [(1, 60), (20, 1200)],
     )
     def test_converts_minutes_to_seconds(self, monkeypatch, minutes, expected_seconds):
-        monkeypatch.setattr(ci, "CI_RUN_TIMEOUT", ci.CI_RUN_TIMEOUT)
+        monkeypatch.setattr(ci, "CI_RUN_TIMEOUT", 0)
 
         ci.set_timeout(minutes)
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from improve.claude import _summarize_tool_input, run_claude
+import improve.claude
+from improve.claude import _summarize_tool_input, run_claude, set_timeout
 
 
 def _make_process(stdout_lines, returncode=0, stderr=""):
@@ -38,6 +39,15 @@ def _tool_stop():
 
 def _result(text):
     return json.dumps({"type": "result", "result": text}) + "\n"
+
+
+class TestSetTimeout:
+    def test_updates_global_timeout(self, monkeypatch):
+        monkeypatch.setattr(improve.claude, "CLAUDE_TIMEOUT", 0)
+
+        set_timeout(300)
+
+        assert improve.claude.CLAUDE_TIMEOUT == 300
 
 
 class TestSummarizeToolInput:
@@ -76,7 +86,7 @@ class TestRunClaude:
             text, elapsed = run_claude("test prompt")
 
         assert text == "Final output"
-        assert elapsed > 0
+        assert isinstance(elapsed, float)
 
     def test_writes_prompt_to_stdin_and_closes(self):
         proc = _make_process([_result("")])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ class TestParseArgs:
     def test_uses_default_values_when_no_args_given(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["iterative-improve"])
         args = _parse_args()
-        assert args.iterations == 10
+        assert args.iterations is None
         assert args.ci_timeout == 15
         assert args.skip_ci is False
         assert args.batch is False
@@ -19,6 +19,8 @@ class TestParseArgs:
         assert "security" in args.phases
         assert args.squash is False
         assert args.ci_provider is None
+        assert args.revert_on_fail is False
+        assert args.phase_timeout == 900
 
     def test_parses_all_custom_values(self, monkeypatch):
         monkeypatch.setattr(
@@ -35,6 +37,9 @@ class TestParseArgs:
                 "--phases",
                 "simplify,security",
                 "--squash",
+                "--revert-on-fail",
+                "--phase-timeout",
+                "300",
             ],
         )
         args = _parse_args()
@@ -45,6 +50,8 @@ class TestParseArgs:
         assert args.resume is True
         assert args.phases == "simplify,security"
         assert args.squash is True
+        assert args.revert_on_fail is True
+        assert args.phase_timeout == 300
 
     @pytest.mark.parametrize("provider", ["github", "gitlab"])
     def test_parses_ci_provider(self, monkeypatch, provider):
@@ -137,6 +144,20 @@ class TestMain:
             main()
         assert exc_info.value.code == 1
 
+    @pytest.mark.parametrize("timeout", ["10", "29"])
+    def test_exits_with_code_1_when_phase_timeout_below_minimum(self, monkeypatch, timeout):
+        monkeypatch.setattr(
+            "sys.argv", ["iterative-improve", "-n", "1", "--phase-timeout", timeout]
+        )
+        with (
+            patch("improve.cli._setup_logging"),
+            patch("improve.cli.check_for_update"),
+            patch("improve.cli.require_tools"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+        assert exc_info.value.code == 1
+
     @pytest.mark.parametrize("timeout", ["0", "-5"])
     def test_exits_with_code_1_when_ci_timeout_below_minimum(self, monkeypatch, timeout):
         monkeypatch.setattr("sys.argv", ["iterative-improve", "-n", "1", "--ci-timeout", timeout])
@@ -148,6 +169,23 @@ class TestMain:
         ):
             main()
         assert exc_info.value.code == 1
+
+    def test_runs_in_continuous_mode_by_default(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["iterative-improve", "--skip-ci"])
+        with (
+            patch("improve.cli._setup_logging"),
+            patch("improve.cli.check_for_update"),
+            patch("improve.cli.require_tools"),
+            patch("improve.cli.ci"),
+            patch("improve.git.branch", return_value="feature"),
+            patch("improve.git.resolve_existing_conflicts", return_value=True),
+            patch("improve.cli.run_preflight"),
+            patch("improve.git.sync_with_main", return_value=True),
+            patch("improve.loop.IterationLoop.run") as mock_run,
+            patch("improve.loop.IterationLoop.install_signal_handlers"),
+        ):
+            main()
+            mock_run.assert_called_once_with(1, 1000)
 
     def test_exits_when_initial_sync_with_main_fails(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["iterative-improve", "-n", "1", "--skip-ci"])

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6,6 +6,36 @@ from improve import git
 from tests import _cp
 
 
+class TestHeadSha:
+    def test_returns_current_head_sha(self):
+        with patch("improve.git.run", return_value=_cp(stdout="abc123def\n")):
+            assert git.head_sha() == "abc123def"
+
+
+class TestRevertTo:
+    def test_returns_true_on_successful_reset_and_push(self):
+        with patch("improve.git.run") as mock_run:
+            mock_run.side_effect = [_cp(), _cp()]
+            assert git.revert_to("abc123", "feature") is True
+
+    def test_returns_false_when_reset_fails(self):
+        with patch("improve.git.run", return_value=_cp(returncode=1, stderr="error")):
+            assert git.revert_to("abc123", "feature") is False
+
+    def test_returns_false_when_force_push_fails(self):
+        with patch("improve.git.run") as mock_run:
+            mock_run.side_effect = [_cp(), _cp(returncode=1, stderr="rejected")]
+            assert git.revert_to("abc123", "feature") is False
+
+
+class TestDiscardChanges:
+    def test_runs_git_checkout(self):
+        with patch("improve.git.run", return_value=_cp()) as mock_run:
+            git.discard_changes()
+
+        mock_run.assert_called_once_with(["git", "checkout", "--", "."])
+
+
 class TestBranch:
     def test_returns_current_branch_name(self):
         with patch("improve.git.run", return_value=_cp(stdout="feature-x\n")):
@@ -398,7 +428,7 @@ class TestApplyWorktreeChanges:
         ):
             files = git.apply_worktree_changes(str(worktree))
 
-        assert files == ["../../etc/passwd"]
+        assert files == []
         assert not (main / "../../etc/passwd").exists()
 
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -8,7 +9,15 @@ from improve.state import LoopState, PhaseResult
 
 
 def _make_loop(
-    tmp_path, monkeypatch, skip_ci=False, batch=False, phases=None, squash=False, parallel=False
+    tmp_path,
+    monkeypatch,
+    skip_ci=False,
+    batch=False,
+    phases=None,
+    squash=False,
+    parallel=False,
+    revert_on_fail=False,
+    continuous=False,
 ):
     monkeypatch.setattr("improve.state.STATE_DIR", tmp_path)
     monkeypatch.setattr("improve.state.STATE_FILE", tmp_path / "state.json")
@@ -22,6 +31,8 @@ def _make_loop(
         phases=phases,
         squash=squash,
         parallel=parallel,
+        revert_on_fail=revert_on_fail,
+        continuous=continuous,
     )
 
 
@@ -127,6 +138,22 @@ class TestRetryCiFixes:
 
         assert passed is False
         assert retries == MAX_CI_RETRIES
+
+    def test_logs_warning_when_all_retries_exhausted(self, tmp_path, monkeypatch, caplog):
+        loop = _make_loop(tmp_path, monkeypatch)
+        with (
+            patch("improve.claude.run_claude", return_value=("out", 1.0)),
+            patch("improve.git.has_changes", return_value=True),
+            patch("improve.ci.get_latest_run_id", return_value=100),
+            patch("improve.git.commit_and_push", return_value=True),
+            patch("improve.ci.wait_for_ci", return_value=(False, "still failing", 2.0)),
+            caplog.at_level(logging.WARNING, logger="improve"),
+        ):
+            passed, retries, _, _ = loop.retry_ci_fixes(False, "err", "Fix")
+
+        assert passed is False
+        assert retries == MAX_CI_RETRIES
+        assert "All 5 attempts exhausted" in caplog.text
 
     def test_accumulates_claude_and_ci_time_across_retries(self, tmp_path, monkeypatch):
         loop = _make_loop(tmp_path, monkeypatch)
@@ -361,6 +388,24 @@ class TestSquashBranch:
 
         mock_squash.assert_not_called()
 
+    def test_excludes_reverted_results_from_squash_message(self, tmp_path, monkeypatch):
+        loop = _make_loop(tmp_path, monkeypatch, squash=True)
+        loop.state.add(PhaseResult(1, "simplify", True, ["a.py"], "Extracted helper", True, 0))
+        loop.state.add(
+            PhaseResult(1, "review", True, ["b.py"], "Reverted change", False, 1, reverted=True)
+        )
+
+        with (
+            patch("improve.git.squash_branch", return_value=True) as mock_squash,
+            patch("improve.git.sync_with_main", return_value=True),
+            patch.object(loop, "run_sequential_iteration", return_value=False),
+        ):
+            loop.run(1, 1)
+
+        message = mock_squash.call_args[0][1]
+        assert "Extracted helper" in message
+        assert "Reverted change" not in message
+
     def test_does_not_squash_when_flag_is_false(self, tmp_path, monkeypatch):
         loop = _make_loop(tmp_path, monkeypatch, squash=False)
         loop.state.add(PhaseResult(1, "simplify", True, ["a.py"], "Stuff", True, 0))
@@ -467,3 +512,234 @@ class TestRunParallelDispatch:
             loop.run(1, 1)
 
         mock_parallel.assert_called_once_with(1)
+
+
+class TestRevertOnFail:
+    def test_sequential_reverts_and_continues_on_ci_failure(self, tmp_path, monkeypatch):
+        loop = _make_loop(tmp_path, monkeypatch, revert_on_fail=True, phases=["simplify", "review"])
+        results = [
+            PhaseResult(1, "simplify", True, ["a.py"], "Stuff", False, 1),
+            PhaseResult(1, "review", True, ["b.py"], "More", True, 0),
+        ]
+
+        with (
+            patch("improve.git.head_sha", return_value="abc123"),
+            patch("improve.git.revert_to", return_value=True) as mock_revert,
+            patch.object(loop, "run_phase", side_effect=results),
+        ):
+            result = loop.run_sequential_iteration(1)
+
+        mock_revert.assert_called_once_with("abc123", "feature")
+        assert result is True
+        reverted = [r for r in loop.state.results if r.get("reverted")]
+        assert len(reverted) == 1
+        assert reverted[0]["phase"] == "simplify"
+
+    def test_sequential_stops_when_revert_fails(self, tmp_path, monkeypatch):
+        loop = _make_loop(tmp_path, monkeypatch, revert_on_fail=True, phases=["simplify", "review"])
+        ci_failed = PhaseResult(1, "simplify", True, ["a.py"], "Stuff", False, 1)
+
+        with (
+            patch("improve.git.head_sha", return_value="abc123"),
+            patch("improve.git.revert_to", return_value=False),
+            patch.object(loop, "run_phase", return_value=ci_failed),
+        ):
+            result = loop.run_sequential_iteration(1)
+
+        assert result is False
+        assert len(loop.state.results) == 1
+
+    def test_sequential_stops_on_ci_failure_without_revert_flag(self, tmp_path, monkeypatch):
+        loop = _make_loop(tmp_path, monkeypatch, revert_on_fail=False)
+        ci_failed = PhaseResult(1, "simplify", True, ["a.py"], "Stuff", False, 0)
+
+        with (
+            patch("improve.git.head_sha", return_value="abc123"),
+            patch.object(loop, "run_phase", return_value=ci_failed),
+        ):
+            result = loop.run_sequential_iteration(1)
+
+        assert result is False
+
+    def test_batch_reverts_all_on_ci_failure(self, tmp_path, monkeypatch):
+        loop = _make_loop(
+            tmp_path,
+            monkeypatch,
+            batch=True,
+            skip_ci=False,
+            revert_on_fail=True,
+            phases=["simplify"],
+        )
+        changed = PhaseResult(1, "simplify", True, ["a.py"], "Stuff", True, 0)
+
+        with (
+            patch("improve.git.head_sha", return_value="abc123"),
+            patch("improve.ci.get_latest_run_id", return_value=100),
+            patch.object(loop, "run_phase", return_value=changed),
+            patch("improve.ci.wait_for_ci", return_value=(False, "error", 2.0)),
+            patch.object(loop, "retry_ci_fixes", return_value=(False, 1, 1.0, 2.0)),
+            patch("improve.git.revert_to", return_value=True) as mock_revert,
+        ):
+            result = loop.run_batch_iteration(1)
+
+        assert result is True
+        mock_revert.assert_called_once_with("abc123", "feature")
+
+    def test_batch_stops_when_revert_fails(self, tmp_path, monkeypatch):
+        loop = _make_loop(
+            tmp_path,
+            monkeypatch,
+            batch=True,
+            skip_ci=False,
+            revert_on_fail=True,
+            phases=["simplify"],
+        )
+        changed = PhaseResult(1, "simplify", True, ["a.py"], "Stuff", True, 0)
+
+        with (
+            patch("improve.git.head_sha", return_value="abc123"),
+            patch("improve.ci.get_latest_run_id", return_value=100),
+            patch.object(loop, "run_phase", return_value=changed),
+            patch("improve.ci.wait_for_ci", return_value=(False, "error", 2.0)),
+            patch.object(loop, "retry_ci_fixes", return_value=(False, 1, 1.0, 2.0)),
+            patch("improve.git.revert_to", return_value=False),
+        ):
+            result = loop.run_batch_iteration(1)
+
+        assert result is False
+
+    def test_parallel_marks_results_as_reverted_on_ci_failure(self, tmp_path, monkeypatch):
+        loop = _make_loop(
+            tmp_path,
+            monkeypatch,
+            parallel=True,
+            skip_ci=False,
+            revert_on_fail=True,
+            phases=["simplify"],
+        )
+        changed = PhaseResult(1, "simplify", True, ["a.py"], "Stuff", True, 0)
+
+        with (
+            patch("improve.git.head_sha", return_value="abc123"),
+            patch(
+                "improve.loop.run_parallel_batch",
+                side_effect=lambda **kwargs: (kwargs["add_result"](changed), True)[1],
+            ),
+        ):
+            result = loop.run_parallel_batch_iteration(1)
+
+        assert result is True
+        reverted = [r for r in loop.state.results if r.get("reverted")]
+        assert len(reverted) == 1
+        assert reverted[0]["phase"] == "simplify"
+
+
+class TestDropConvergedPhases:
+    def test_crashed_phase_is_not_dropped_from_active_phases(self, tmp_path, monkeypatch):
+        loop = _make_loop(tmp_path, monkeypatch, phases=["simplify", "review"], skip_ci=True)
+        results = [
+            PhaseResult.crashed(1, "simplify"),
+            PhaseResult(1, "review", True, ["b.py"], "Fixed", True, 0),
+        ]
+
+        loop._drop_converged_phases(results)
+
+        assert "simplify" in loop._active_phases
+
+    def test_converged_phase_is_dropped_from_active_phases(self, tmp_path, monkeypatch):
+        loop = _make_loop(tmp_path, monkeypatch, phases=["simplify", "review"], skip_ci=True)
+        results = [
+            PhaseResult(1, "simplify", False, [], "No changes needed", True, 0),
+            PhaseResult(1, "review", True, ["b.py"], "Fixed", True, 0),
+        ]
+
+        loop._drop_converged_phases(results)
+
+        assert "simplify" not in loop._active_phases
+        assert "review" in loop._active_phases
+
+
+class TestCrashRecovery:
+    def test_sequential_continues_after_phase_crash(self, tmp_path, monkeypatch):
+        loop = _make_loop(tmp_path, monkeypatch, phases=["simplify", "review"], skip_ci=True)
+        ok_result = PhaseResult(1, "review", True, ["b.py"], "Fixed", True, 0)
+
+        with (
+            patch("improve.git.head_sha", return_value="abc"),
+            patch.object(
+                loop,
+                "run_phase",
+                side_effect=[RuntimeError("boom"), ok_result],
+            ),
+            patch("improve.git.discard_changes"),
+        ):
+            result = loop.run_sequential_iteration(1)
+
+        assert result is True
+        assert len(loop.state.results) == 2
+        assert loop.state.results[0]["summary"] == "Phase crashed"
+        assert loop.state.results[1]["changes_made"] is True
+
+    def test_batch_continues_after_phase_crash(self, tmp_path, monkeypatch):
+        loop = _make_loop(
+            tmp_path,
+            monkeypatch,
+            batch=True,
+            skip_ci=True,
+            phases=["simplify", "review"],
+        )
+        ok_result = PhaseResult(1, "review", True, ["b.py"], "Fixed", True, 0)
+
+        with (
+            patch("improve.git.head_sha", return_value="abc"),
+            patch.object(
+                loop,
+                "run_phase",
+                side_effect=[RuntimeError("crash"), ok_result],
+            ),
+            patch("improve.git.discard_changes"),
+        ):
+            result = loop.run_batch_iteration(1)
+
+        assert result is True
+        assert loop.state.results[0]["summary"] == "Phase crashed"
+
+
+class TestContinuousMode:
+    def test_shows_iteration_without_max_in_continuous_mode(self, tmp_path, monkeypatch, capsys):
+        loop = _make_loop(tmp_path, monkeypatch, continuous=True)
+
+        with (
+            patch("improve.git.sync_with_main", return_value=True),
+            patch.object(loop, "run_sequential_iteration", return_value=False),
+        ):
+            loop.run(1, 1000)
+
+        output = capsys.readouterr().out
+        assert "Iteration 1 ---" in output
+        assert "1/1000" not in output
+
+    def test_shows_iteration_with_max_when_not_continuous(self, tmp_path, monkeypatch, capsys):
+        loop = _make_loop(tmp_path, monkeypatch, continuous=False)
+
+        with (
+            patch("improve.git.sync_with_main", return_value=True),
+            patch.object(loop, "run_sequential_iteration", return_value=False),
+        ):
+            loop.run(1, 5)
+
+        output = capsys.readouterr().out
+        assert "Iteration 1/5 ---" in output
+
+
+class TestPrintSummaryReverted:
+    def test_shows_reverted_status_for_reverted_phases(self, tmp_path, monkeypatch, capsys):
+        loop = _make_loop(tmp_path, monkeypatch)
+        result = PhaseResult(1, "simplify", True, ["a.py"], "Stuff", False, 1, reverted=True)
+        loop.state.add(result)
+
+        loop.print_summary(10.0)
+
+        output = capsys.readouterr().out
+        assert "CI:REVT" in output
+        assert "Reverted:       1" in output

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,6 +1,7 @@
+from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
 
-from improve.parallel import run_parallel_batch, run_phase_in_worktree
+from improve.parallel import _collect_results, run_parallel_batch, run_phase_in_worktree
 from improve.state import PhaseResult
 
 
@@ -35,6 +36,30 @@ class TestRunPhaseInWorktree:
         _, kwargs = mock_claude.call_args
         assert kwargs["cwd"] == "/tmp/wt"
         assert kwargs["quiet"] is True
+
+
+class TestCollectResults:
+    def test_returns_crashed_result_when_future_raises(self):
+        ok_future = MagicMock(spec=Future)
+        ok_future.result.return_value = PhaseResult(
+            1,
+            "simplify",
+            True,
+            ["a.py"],
+            "Fixed",
+            True,
+            0,
+        )
+        bad_future = MagicMock(spec=Future)
+        bad_future.result.side_effect = RuntimeError("boom")
+
+        results = _collect_results([ok_future, bad_future], ["simplify", "review"], 1)
+
+        assert len(results) == 2
+        assert results[0].changes_made is True
+        assert results[1].changes_made is False
+        assert results[1].summary == "Phase crashed"
+        assert results[1].phase == "review"
 
 
 class TestRunParallelBatch:
@@ -153,6 +178,36 @@ class TestRunParallelBatch:
             )
 
         assert result is True
+
+    def test_reverts_on_ci_failure_when_revert_sha_provided(self):
+        changed = PhaseResult(1, "simplify", True, ["a.py"], "Fixed", True, 0)
+        retry = MagicMock(return_value=(False, 1, 1.0, 2.0))
+
+        with (
+            patch("improve.parallel.git.diff_vs_main", return_value="a.py"),
+            patch("improve.parallel.ci.get_latest_run_id", return_value=100),
+            patch("improve.parallel.git.create_worktree", return_value=True),
+            patch("improve.parallel.git.remove_worktree"),
+            patch("improve.parallel.git.apply_worktree_changes", return_value=["a.py"]),
+            patch("improve.parallel.git.commit_and_push", return_value=True),
+            patch("improve.parallel.ci.wait_for_ci", return_value=(False, "error", 2.0)),
+            patch("improve.parallel.git.revert_to", return_value=True) as mock_revert,
+            patch("improve.parallel.run_phase_in_worktree", return_value=changed),
+            patch("tempfile.mkdtemp", return_value="/tmp/improve-test"),
+        ):
+            result = run_parallel_batch(
+                ["simplify"],
+                1,
+                "feature",
+                "None",
+                False,
+                MagicMock(),
+                retry,
+                revert_sha="abc123",
+            )
+
+        assert result is True
+        mock_revert.assert_called_once_with("abc123", "feature")
 
     def test_returns_false_when_push_fails(self):
         changed = PhaseResult(1, "simplify", True, ["a.py"], "Fixed", True, 0)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -10,28 +10,27 @@ class TestRunPreflight:
     def test_runs_all_checks_when_ci_enabled(self):
         with patch("improve.preflight.run", return_value=_cp()) as mock_run:
             preflight.run_preflight("feature-x", "gh", skip_ci=False)
-            assert mock_run.call_count == 4
-            mock_run.assert_any_call(["git", "ls-remote", "--heads", "origin"], timeout=15)
-            mock_run.assert_any_call(
-                ["git", "push", "--dry-run", "origin", "feature-x"], timeout=15
-            )
-            mock_run.assert_any_call(["gh", "auth", "status"], timeout=15)
-            mock_run.assert_any_call(["gh", "repo", "view", "--json", "name"], timeout=15)
+
+        assert mock_run.call_count == 4
+        mock_run.assert_any_call(["git", "ls-remote", "--heads", "origin"], timeout=15)
+        mock_run.assert_any_call(["git", "push", "--dry-run", "origin", "feature-x"], timeout=15)
+        mock_run.assert_any_call(["gh", "auth", "status"], timeout=15)
+        mock_run.assert_any_call(["gh", "repo", "view", "--json", "name"], timeout=15)
 
     def test_skips_ci_checks_when_skip_ci_is_true(self):
         with patch("improve.preflight.run", return_value=_cp()) as mock_run:
             preflight.run_preflight("feature-x", "gh", skip_ci=True)
-            assert mock_run.call_count == 2
-            mock_run.assert_any_call(["git", "ls-remote", "--heads", "origin"], timeout=15)
-            mock_run.assert_any_call(
-                ["git", "push", "--dry-run", "origin", "feature-x"], timeout=15
-            )
+
+        assert mock_run.call_count == 2
+        mock_run.assert_any_call(["git", "ls-remote", "--heads", "origin"], timeout=15)
+        mock_run.assert_any_call(["git", "push", "--dry-run", "origin", "feature-x"], timeout=15)
 
     def test_uses_glab_commands_for_gitlab(self):
         with patch("improve.preflight.run", return_value=_cp()) as mock_run:
             preflight.run_preflight("feature-x", "glab", skip_ci=False)
-            mock_run.assert_any_call(["glab", "auth", "status"], timeout=15)
-            mock_run.assert_any_call(["glab", "repo", "view"], timeout=15)
+
+        mock_run.assert_any_call(["glab", "auth", "status"], timeout=15)
+        mock_run.assert_any_call(["glab", "repo", "view"], timeout=15)
 
     def test_stops_at_first_failing_check(self):
         with (

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,30 +1,39 @@
 import json
+from dataclasses import asdict
 
-from improve.state import LoopState, PhaseResult
+from improve.state import LoopState, PhaseResult, format_summary
 
 
 class TestPhaseResult:
-    def test_creates_phase_result_with_all_fields(self):
-        result = PhaseResult(
-            iteration=1,
-            phase="simplify",
-            changes_made=True,
-            files=["a.py"],
-            summary="Extracted helper",
-            ci_passed=True,
-            ci_retries=0,
-        )
-        assert result.iteration == 1
-        assert result.phase == "simplify"
-        assert result.changes_made is True
-        assert result.files == ["a.py"]
-        assert result.ci_passed is True
-
-    def test_defaults_duration_fields_to_zero(self):
+    def test_uses_safe_defaults_for_optional_fields(self):
         result = PhaseResult(1, "review", False, [], "No changes", True, 0)
+
         assert result.duration_seconds == 0.0
         assert result.claude_seconds == 0.0
         assert result.ci_seconds == 0.0
+        assert result.reverted is False
+
+    def test_no_changes_factory_returns_inactive_result_with_timing(self):
+        result = PhaseResult.no_changes(2, "simplify", duration=5.0, claude_seconds=3.0)
+        assert result.iteration == 2
+        assert result.phase == "simplify"
+        assert result.changes_made is False
+        assert result.files == []
+        assert result.summary == "No changes needed"
+        assert result.ci_passed is True
+        assert result.ci_retries == 0
+        assert result.duration_seconds == 5.0
+        assert result.claude_seconds == 3.0
+
+    def test_crashed_factory_returns_inactive_result(self):
+        result = PhaseResult.crashed(3, "review")
+        assert result.iteration == 3
+        assert result.phase == "review"
+        assert result.changes_made is False
+        assert result.files == []
+        assert result.summary == "Phase crashed"
+        assert result.ci_passed is True
+        assert result.ci_retries == 0
 
 
 class TestLoopState:
@@ -51,6 +60,18 @@ class TestLoopState:
         context = state.context()
         assert "Extracted helper" in context
         assert "No changes" not in context
+
+    def test_context_excludes_reverted_results(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("improve.state.STATE_DIR", tmp_path)
+        monkeypatch.setattr("improve.state.STATE_FILE", tmp_path / "state.json")
+        state = LoopState(branch="feature", started_at="2025-01-01T00:00:00")
+        state.add(PhaseResult(1, "simplify", True, ["a.py"], "Extracted helper", True, 0))
+        state.add(
+            PhaseResult(1, "review", True, ["b.py"], "Reverted change", False, 1, reverted=True)
+        )
+        context = state.context()
+        assert "Extracted helper" in context
+        assert "Reverted change" not in context
 
     def test_save_and_load_round_trips(self, tmp_path, monkeypatch):
         monkeypatch.setattr("improve.state.STATE_DIR", tmp_path)
@@ -80,3 +101,29 @@ class TestLoopState:
         bad_file.write_text(json.dumps({"iteration": 1}))
         monkeypatch.setattr("improve.state.STATE_FILE", bad_file)
         assert LoopState.load() is None
+
+
+class TestFormatSummary:
+    def test_includes_result_details(self):
+        results = [asdict(PhaseResult(1, "simplify", True, ["a.py"], "Extracted helper", True, 0))]
+
+        output = format_summary(results, 10.0)
+
+        assert "RESULTS" in output
+        assert "Extracted helper" in output
+        assert "CI:PASS" in output
+
+    def test_shows_reverted_status(self):
+        result = PhaseResult(1, "simplify", True, ["a.py"], "Stuff", False, 1, reverted=True)
+        results = [asdict(result)]
+
+        output = format_summary(results, 10.0)
+
+        assert "CI:REVT" in output
+        assert "Reverted:       1" in output
+
+    def test_shows_zero_counts_for_empty_results(self):
+        output = format_summary([], 0.0)
+
+        assert "Phases run:     0" in output
+        assert "Reverted:       0" in output

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "iterative-improve"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- **Revert on CI failure** (`--revert-on-fail`): discard bad changes and continue instead of stopping
- **Crash recovery**: phase exceptions are caught, working tree cleaned, loop continues
- **Configurable phase timeout** (`--phase-timeout`): replace hardcoded 900s Claude subprocess timeout
- **Continuous mode** (now default): run until convergence; use `-n` to cap iterations

## Changes
- `git.py`: add `head_sha()`, `revert_to()`, `discard_changes()`
- `claude.py`: add `set_timeout()`
- `loop.py`: add `_run_phase_safe()` crash wrapper, revert logic in sequential/batch/parallel modes, continuous iteration display
- `parallel.py`: crash recovery in `_collect_results()`, revert support via `revert_sha` param
- `state.py`: add `reverted` field to `PhaseResult`, extract `format_summary()`
- `cli.py`: add `--revert-on-fail`, `--phase-timeout` args; make continuous the default (no `-n` needed)
- 23 new tests (425 total), 94% coverage

Closes #18

## Test plan
- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run pytest -v --tb=short --cov=improve` — 425 passed, 94% coverage
- [x] Architecture tests pass (file length, nesting depth, import boundaries)