### PR TITLE
Add colored terminal output

### DIFF
--- a/src/improve/cli.py
+++ b/src/improve/cli.py
@@ -6,7 +6,7 @@ import sys
 import threading
 from datetime import datetime
 
-from improve import ci, claude, git
+from improve import ci, claude, color, git
 from improve.ci_gitlab import GitLabCI
 from improve.loop import IterationLoop
 from improve.preflight import run_preflight
@@ -24,7 +24,7 @@ def _setup_logging() -> None:
 
     console = logging.StreamHandler()
     console.setLevel(logging.INFO)
-    console.setFormatter(logging.Formatter("  %(asctime)s [%(message)s", datefmt="%H:%M:%S"))
+    console.setFormatter(color.ColorFormatter("  %(asctime)s [%(message)s", datefmt="%H:%M:%S"))
 
     file_handler = logging.FileHandler(LOG_FILE, mode="a")
     file_handler.setLevel(logging.DEBUG)
@@ -84,6 +84,7 @@ def _parse_args() -> argparse.Namespace:
         default=900,
         help="Phase timeout in seconds (default: %(default)s)",
     )
+    parser.add_argument("--no-color", action="store_true", help="Disable colored output")
     return parser.parse_args()
 
 
@@ -105,6 +106,7 @@ def _validate_phases(raw: str) -> list[str]:
 
 def main() -> None:
     args = _parse_args()
+    color.init(force_no_color=args.no_color)
     _setup_logging()
     threading.Thread(target=check_for_update, daemon=True).start()
     platform = args.ci_provider or git.detect_platform()
@@ -171,8 +173,9 @@ def main() -> None:
 
     mode = "parallel" if args.parallel else ("batch" if args.batch else "sequential")
     iter_display = "continuous" if continuous else f"{start_iteration}-{max_iterations}"
+    border = color.wrap("=" * 50, color.BOLD + color.CYAN)
     header = (
-        f"\n{'=' * 50}\n"
+        f"\n{border}\n"
         f"  Iterative Improvement Loop v{get_installed_version()}\n"
         f"  Branch:     {current_branch}\n"
         f"  Iterations: {iter_display}\n"
@@ -181,7 +184,7 @@ def main() -> None:
         f"  CI:         {'skip' if args.skip_ci else f'{args.ci_timeout}m timeout'}\n"
         f"  Revert:     {'yes' if args.revert_on_fail else 'no'}\n"
         f"  Squash:     {'yes' if args.squash else 'no'}\n"
-        f"{'=' * 50}"
+        f"{border}"
     )
     print(header)
     logger.info(

--- a/src/improve/color.py
+++ b/src/improve/color.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+enabled = False
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RED = "\033[31m"
+BLUE = "\033[34m"
+MAGENTA = "\033[35m"
+CYAN = "\033[36m"
+BOLD_WHITE = "\033[1;37m"
+DARK_GREEN = "\033[38;5;28m"
+DARK_YELLOW = "\033[38;5;178m"
+DARK_RED = "\033[38;5;124m"
+GRAY = "\033[90m"
+
+PHASE_COLORS = {"simplify": DARK_GREEN, "review": DARK_YELLOW, "security": DARK_RED}
+TAG_COLORS = {
+    "loop": BOLD_WHITE,
+    "ci": CYAN,
+    "ci-fix": CYAN,
+    "git": BLUE,
+    "sync": BLUE,
+    "claude": MAGENTA,
+    "signal": DARK_YELLOW,
+    "update": GRAY,
+    "preflight": GRAY,
+    "state": GRAY,
+}
+
+
+def init(force_no_color: bool = False) -> None:
+    global enabled
+    if force_no_color or os.environ.get("NO_COLOR") or os.environ.get("TERM") == "dumb":
+        enabled = False
+        return
+    enabled = sys.stdout.isatty()
+
+
+def wrap(text: str, code: str) -> str:
+    return f"{code}{text}{RESET}" if enabled else text
+
+
+def phase_color(phase: str) -> str:
+    return PHASE_COLORS.get(phase, "")
+
+
+class ColorFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        msg = record.getMessage()
+        if not enabled or "]" not in msg:
+            return super().format(record)
+        tag, rest = msg.split("]", 1)
+        color = TAG_COLORS.get(tag.strip(), PHASE_COLORS.get(tag.strip(), ""))
+        if color:
+            record.msg = f"{color}{tag}]{RESET}{rest}"
+            record.args = ()
+        return super().format(record)

--- a/src/improve/loop.py
+++ b/src/improve/loop.py
@@ -6,7 +6,7 @@ import sys
 import time
 from dataclasses import replace
 
-from improve import ci, claude, git
+from improve import ci, claude, color, git
 from improve.parallel import run_parallel_batch
 from improve.process import format_duration
 from improve.prompt import (
@@ -274,7 +274,7 @@ class IterationLoop:
         self.loop_start = time.monotonic()
         for i in range(start_iteration, max_iterations + 1):
             label = str(i) if self.continuous else f"{i}/{max_iterations}"
-            print(f"\n--- Iteration {label} ---")
+            print(color.wrap(f"\n--- Iteration {label} ---", color.BOLD_WHITE))
             logger.info("loop] === Iteration %s ===", label)
             self.state.iteration = i
             self.state.save()

--- a/src/improve/state.py
+++ b/src/improve/state.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from improve import color
 from improve.process import format_duration
 
 logger = logging.getLogger("improve")
@@ -102,33 +103,38 @@ class LoopState:
 
 def _ci_label(r: dict) -> str:
     if r.get("reverted"):
-        return "REVT"
-    return "PASS" if r["ci_passed"] else "FAIL"
+        return color.wrap("REVT", color.DARK_YELLOW)
+    return color.wrap("PASS", color.DARK_GREEN) if r["ci_passed"] else color.wrap("FAIL", color.RED)
 
 
 def format_summary(results: list[dict], total_elapsed: float) -> str:
     total_claude = sum(r.get("claude_seconds", 0) for r in results)
     total_ci = sum(r.get("ci_seconds", 0) for r in results)
     overhead = format_duration(max(0, total_elapsed - total_claude - total_ci))
+    banner = color.wrap("=" * 60, color.BOLD + color.CYAN)
     lines = [
-        f"\n{'=' * 60}",
-        "RESULTS",
-        f"{'=' * 60}",
+        f"\n{banner}",
+        color.wrap("RESULTS", color.BOLD + color.CYAN),
+        banner,
         f"  Phases run:     {len(results)}",
         f"  With changes:   {sum(1 for r in results if r['changes_made'])}",
         f"  CI fixes:       {sum(r['ci_retries'] for r in results)}",
         f"  Reverted:       {sum(1 for r in results if r.get('reverted'))}",
-        f"  Total time:     {format_duration(total_elapsed)}",
-        f"  Claude time:    {format_duration(total_claude)}",
-        f"  CI time:        {format_duration(total_ci)}",
-        f"  Overhead:       {overhead}",
+        f"  Total time:     {color.wrap(format_duration(total_elapsed), color.DIM)}",
+        f"  Claude time:    {color.wrap(format_duration(total_claude), color.DIM)}",
+        f"  CI time:        {color.wrap(format_duration(total_ci), color.DIM)}",
+        f"  Overhead:       {color.wrap(overhead, color.DIM)}",
         "",
     ]
     for r in results:
-        marker = "+" if r["changes_made"] else " "
-        dur = format_duration(r.get("duration_seconds", 0))
-        lines.append(
-            f"  [{marker}] {r['phase']:10s} | CI:{_ci_label(r)} | {dur:>9s} | {r['summary']}"
-        )
+        marker_char = "+" if r["changes_made"] else " "
+        if marker_char == "+":
+            marker = color.wrap(f"[{marker_char}]", color.BOLD + color.DARK_GREEN)
+        else:
+            marker = f"[{marker_char}]"
+        phase_name = color.wrap(r["phase"], color.phase_color(r["phase"]))
+        dur = color.wrap(format_duration(r.get("duration_seconds", 0)), color.DIM)
+        ci_label = _ci_label(r)
+        lines.append(f"  {marker} {phase_name:>21s} | CI:{ci_label} | {dur:>20s} | {r['summary']}")
     lines.extend([f"\n  State: {STATE_FILE}", f"  Log:   {LOG_FILE}"])
     return "\n".join(lines)

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -18,6 +18,7 @@ ALLOWED_IMPORTS = {
         "improve.ci",
         "improve.ci_gitlab",
         "improve.claude",
+        "improve.color",
         "improve.git",
         "improve.loop",
         "improve.preflight",
@@ -26,10 +27,12 @@ ALLOWED_IMPORTS = {
         "improve.state",
         "improve.version",
     },
+    "color": set(),
     "loop": {
         "improve",
         "improve.ci",
         "improve.claude",
+        "improve.color",
         "improve.git",
         "improve.parallel",
         "improve.process",
@@ -52,11 +55,11 @@ ALLOWED_IMPORTS = {
     "preflight": {"improve.process"},
     "process": set(),
     "prompt": set(),
-    "state": {"improve.process"},
+    "state": {"improve", "improve.process"},
     "version": set(),
 }
 
-ALLOWED_MUTABLE_GLOBALS = {}
+ALLOWED_MUTABLE_GLOBALS = {"color": {"enabled"}}
 
 SECRET_PATTERNS = ["password", "secret", "api_key", "token", "private_key"]
 

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+
+from improve import color
+
+
+class TestInit:
+    def test_disables_color_when_force_no_color_is_true(self):
+        color.init(force_no_color=True)
+        assert color.enabled is False
+
+    def test_disables_color_when_no_color_env_is_set(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        color.init()
+        assert color.enabled is False
+
+    def test_disables_color_when_term_is_dumb(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("TERM", "dumb")
+        color.init()
+        assert color.enabled is False
+
+    def test_disables_color_when_stdout_is_not_a_tty(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.delenv("TERM", raising=False)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        color.init()
+        assert color.enabled is False
+
+    def test_enables_color_when_stdout_is_a_tty(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.delenv("TERM", raising=False)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        color.init()
+        assert color.enabled is True
+
+
+class TestWrap:
+    def test_returns_plain_text_when_disabled(self):
+        color.enabled = False
+        assert color.wrap("hello", color.RED) == "hello"
+
+    def test_wraps_text_with_ansi_codes_when_enabled(self):
+        color.enabled = True
+        result = color.wrap("hello", color.RED)
+        assert result == f"{color.RED}hello{color.RESET}"
+
+
+class TestPhaseColor:
+    def test_returns_dark_green_for_simplify(self):
+        assert color.phase_color("simplify") == color.DARK_GREEN
+
+    def test_returns_dark_yellow_for_review(self):
+        assert color.phase_color("review") == color.DARK_YELLOW
+
+    def test_returns_dark_red_for_security(self):
+        assert color.phase_color("security") == color.DARK_RED
+
+    def test_returns_empty_string_for_unknown_phase(self):
+        assert color.phase_color("unknown") == ""
+
+
+class TestColorFormatter:
+    def test_colorizes_known_tag_when_enabled(self):
+        color.enabled = True
+        formatter = color.ColorFormatter("%(message)s")
+        record = logging.LogRecord("test", logging.INFO, "", 0, "loop] started", (), None)
+        result = formatter.format(record)
+        assert result.startswith(color.BOLD_WHITE)
+        assert "loop]" in result
+
+    def test_returns_plain_message_when_disabled(self):
+        color.enabled = False
+        formatter = color.ColorFormatter("%(message)s")
+        record = logging.LogRecord("test", logging.INFO, "", 0, "loop] started", (), None)
+        result = formatter.format(record)
+        assert result == "loop] started"
+
+    def test_returns_plain_message_when_no_bracket(self):
+        color.enabled = True
+        formatter = color.ColorFormatter("%(message)s")
+        record = logging.LogRecord("test", logging.INFO, "", 0, "no bracket here", (), None)
+        result = formatter.format(record)
+        assert result == "no bracket here"
+
+    def test_colorizes_phase_tag(self):
+        color.enabled = True
+        formatter = color.ColorFormatter("%(message)s")
+        record = logging.LogRecord("test", logging.INFO, "", 0, "simplify] Running...", (), None)
+        result = formatter.format(record)
+        assert result.startswith(color.DARK_GREEN)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -734,6 +734,9 @@ class TestContinuousMode:
 
 class TestPrintSummaryReverted:
     def test_shows_reverted_status_for_reverted_phases(self, tmp_path, monkeypatch, capsys):
+        from improve import color
+
+        color.enabled = False
         loop = _make_loop(tmp_path, monkeypatch)
         result = PhaseResult(1, "simplify", True, ["a.py"], "Stuff", False, 1, reverted=True)
         loop.state.add(result)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,6 +1,9 @@
 import json
 from dataclasses import asdict
 
+import pytest
+
+from improve import color
 from improve.state import LoopState, PhaseResult, format_summary
 
 
@@ -104,6 +107,10 @@ class TestLoopState:
 
 
 class TestFormatSummary:
+    @pytest.fixture(autouse=True)
+    def _disable_color(self):
+        color.enabled = False
+
     def test_includes_result_details(self):
         results = [asdict(PhaseResult(1, "simplify", True, ["a.py"], "Extracted helper", True, 0))]
 


### PR DESCRIPTION
## Summary
- Add ANSI color support to terminal output with automatic TTY detection
- Color-code log tags (loop, ci, git, claude, etc.) and phase names (simplify, review, security)
- Add `--no-color` flag and respect `NO_COLOR` env var / `TERM=dumb`
- Colorize iteration headers, results banner, CI status labels, and phase markers

## Test plan
- [x] Unit tests for color module (init, wrap, phase_color, ColorFormatter)
- [x] Existing tests updated to disable color where output is asserted
- [x] Architecture tests updated for new module
- [ ] Manual: verify colored output in terminal
- [ ] Manual: verify `--no-color` and `NO_COLOR=1` disable colors