### PR TITLE
Fix release workflow paths and randomize mutmut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,20 @@ jobs:
 
       - run: uv sync --dev
 
+      - name: Pick random source file for mutation testing
+        id: pick
+        run: |
+          FILE=$(find improve/ -name '*.py' \
+            ! -name '__init__.py' ! -name 'version.py' ! -name 'color.py' \
+            | shuf -n 1)
+          echo "file=$FILE" >> "$GITHUB_OUTPUT"
+          echo "Mutating: $FILE"
+
       - name: Run mutation testing (sampled, 7min max)
         run: |
+          TARGET="${{ steps.pick.outputs.file }}"
           timeout 420 uv run mutmut run \
-            --paths-to-mutate=improve/ \
-            --paths-to-exclude=improve/__init__.py,improve/version.py,improve/color.py \
+            --paths-to-mutate="$TARGET" \
             || rc=$?
           rc=${rc:-0}
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ] && [ "$rc" -ne 4 ] && [ "$rc" -ne 124 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,10 @@ jobs:
           echo "file=$FILE" >> "$GITHUB_OUTPUT"
           echo "Mutating: $FILE"
 
-      - name: Run mutation testing (sampled, 7min max)
+      - name: Run mutation testing (sampled, 5min max)
         run: |
           TARGET="${{ steps.pick.outputs.file }}"
-          timeout 420 uv run mutmut run \
+          timeout 300 uv run mutmut run \
             --paths-to-mutate="$TARGET" \
             || rc=$?
           rc=${rc:-0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,20 +59,14 @@ jobs:
 
       - run: uv sync --dev
 
-      - name: Pick random source file for mutation testing
-        id: pick
+      - name: Run mutation testing (randomized, 5min max)
         run: |
-          FILE=$(find improve/ -name '*.py' \
+          FILES=$(find improve/ -name '*.py' \
             ! -name '__init__.py' ! -name 'version.py' ! -name 'color.py' \
-            | shuf -n 1)
-          echo "file=$FILE" >> "$GITHUB_OUTPUT"
-          echo "Mutating: $FILE"
-
-      - name: Run mutation testing (sampled, 5min max)
-        run: |
-          TARGET="${{ steps.pick.outputs.file }}"
+            | shuf | tr '\n' ',')
+          echo "Mutation order: $FILES"
           timeout 300 uv run mutmut run \
-            --paths-to-mutate="$TARGET" \
+            --paths-to-mutate="${FILES%,}" \
             || rc=$?
           rc=${rc:-0}
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ] && [ "$rc" -ne 4 ] && [ "$rc" -ne 124 ]; then

--- a/.github/workflows/mutation-nightly.yml
+++ b/.github/workflows/mutation-nightly.yml
@@ -1,0 +1,47 @@
+name: Mutation (nightly)
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  mutation-full:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - run: uv sync --dev
+
+      - name: Run full mutation testing (60min max)
+        run: |
+          timeout 3600 uv run mutmut run \
+            --paths-to-mutate=improve/ \
+            --paths-to-exclude=improve/__init__.py,improve/version.py,improve/color.py \
+            || rc=$?
+          rc=${rc:-0}
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ] && [ "$rc" -ne 4 ] && [ "$rc" -ne 124 ]; then
+            exit $rc
+          fi
+          uv run python3 -c "
+          import sqlite3, sys
+          db = sqlite3.connect('.mutmut-cache')
+          rows = db.execute('SELECT status, count(*) FROM Mutant GROUP BY status').fetchall()
+          stats = dict(rows)
+          killed = stats.get('ok_killed', 0)
+          survived = stats.get('bad_survived', 0)
+          timeout = stats.get('bad_timeout', 0)
+          total = killed + survived + timeout
+          if total < 30:
+              print(f'Only {total} mutants tested — too few for reliable rate, passing')
+              sys.exit(0)
+          rate = killed * 100 / total
+          print(f'Mutation kill rate: {rate:.1f}% ({killed}/{total} tested)')
+          if rate < 60:
+              print(f'FAIL: {rate:.1f}% is below 60% threshold')
+              sys.exit(1)
+          "

--- a/.github/workflows/mutation-nightly.yml
+++ b/.github/workflows/mutation-nightly.yml
@@ -17,9 +17,9 @@ jobs:
 
       - run: uv sync --dev
 
-      - name: Run full mutation testing (60min max)
+      - name: Run full mutation testing (3h max)
         run: |
-          timeout 3600 uv run mutmut run \
+          timeout 10800 uv run mutmut run \
             --paths-to-mutate=improve/ \
             --paths-to-exclude=improve/__init__.py,improve/version.py,improve/color.py \
             || rc=$?

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
       - run: uv sync --dev
 
       - name: Ruff check
-        run: uv run ruff check src/ tests/
+        run: uv run ruff check improve/ tests/
 
       - name: Ruff format
-        run: uv run ruff format --check src/ tests/
+        run: uv run ruff format --check improve/ tests/
 
       - name: Run tests
         run: uv run pytest -v --tb=short

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -143,6 +144,77 @@ class TestWaitForCi:
             passed, _errors, _elapsed = ci.wait_for_ci("feature", known_previous_id=100)
 
         assert passed is False
+
+    def test_logs_waiting_message(self, caplog):
+        with (
+            patch("improve.ci._wait_for_new_run", return_value=None),
+            caplog.at_level(logging.INFO, logger="improve"),
+        ):
+            ci.wait_for_ci("feature", known_previous_id=100)
+
+        assert "Waiting for CI run" in caplog.text
+
+    def test_logs_skipping_when_no_run_detected(self, caplog):
+        with (
+            patch("improve.ci._wait_for_new_run", return_value=None),
+            caplog.at_level(logging.INFO, logger="improve"),
+        ):
+            ci.wait_for_ci("feature", known_previous_id=100)
+
+        assert "No CI run detected" in caplog.text
+
+    def test_logs_passed_message_on_success(self, caplog):
+        with (
+            patch("improve.ci._wait_for_new_run", return_value=200),
+            patch.object(ci._provider, "watch_run", return_value=True),
+            caplog.at_level(logging.INFO, logger="improve"),
+        ):
+            ci.wait_for_ci("feature", known_previous_id=100)
+
+        assert "Passed in" in caplog.text
+
+    def test_logs_failed_message_on_failure(self, caplog):
+        with (
+            patch("improve.ci._wait_for_new_run", return_value=200),
+            patch.object(ci._provider, "watch_run", return_value=False),
+            patch.object(ci._provider, "get_run_conclusion", return_value="failure"),
+            patch.object(ci._provider, "get_failed_logs", return_value="err"),
+            caplog.at_level(logging.WARNING, logger="improve"),
+        ):
+            ci.wait_for_ci("feature", known_previous_id=100)
+
+        assert "Failed after" in caplog.text
+
+    def test_logs_cancelled_retry_message(self, caplog):
+        with (
+            patch("improve.ci._wait_for_new_run", side_effect=[200, 300]),
+            patch.object(ci._provider, "watch_run", side_effect=[False, True]),
+            patch.object(ci._provider, "get_run_conclusion", return_value="cancelled"),
+            caplog.at_level(logging.INFO, logger="improve"),
+        ):
+            ci.wait_for_ci("feature", known_previous_id=100)
+
+        assert "was cancelled" in caplog.text
+
+    def test_returns_positive_elapsed_time(self):
+        with (
+            patch("improve.ci._wait_for_new_run", return_value=200),
+            patch.object(ci._provider, "watch_run", return_value=True),
+        ):
+            _passed, _errors, elapsed = ci.wait_for_ci("feature", known_previous_id=100)
+
+        assert elapsed >= 0
+
+    def test_settle_breaks_when_get_latest_returns_none(self, monkeypatch):
+        monkeypatch.setattr(ci, "CI_SETTLE_DELAY", 0)
+        monkeypatch.setattr(ci, "CI_SETTLE_CHECKS", 3)
+        with (
+            patch("improve.ci.time.sleep"),
+            patch("improve.ci.get_latest_run_id", side_effect=[200, None]),
+        ):
+            result = ci._wait_for_new_run("feature", 100)
+
+        assert result == 200
 
 
 class TestWaitForNewRun:

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from improve import ci
+from improve.ci import CIProvider
 from improve.ci_gh import GitHubCI
 from tests import _cp
 
@@ -29,6 +30,15 @@ class TestSetProvider:
         ci.set_provider(new_provider)
 
         assert ci._provider is new_provider
+
+    def test_accepts_any_ci_provider_implementation(self, monkeypatch):
+        original = ci._provider
+        monkeypatch.setattr(ci, "_provider", original)
+        provider: CIProvider = GitHubCI()
+
+        ci.set_provider(provider)
+
+        assert ci._provider is provider
 
 
 class TestGetLatestRunId:
@@ -136,8 +146,24 @@ class TestWaitForCi:
 
 
 class TestWaitForNewRun:
+    @pytest.fixture(autouse=True)
+    def _mock_time(self):
+        self._clock = 0.0
+
+        def monotonic():
+            return self._clock
+
+        def sleep(seconds):
+            self._clock += seconds
+
+        with (
+            patch("improve.ci.time.monotonic", side_effect=monotonic),
+            patch("improve.ci.time.sleep", side_effect=sleep),
+        ):
+            yield
+
     def test_returns_new_run_after_settle(self, monkeypatch):
-        monkeypatch.setattr(ci, "CI_SETTLE_DELAY", 0)
+        monkeypatch.setattr(ci, "CI_SETTLE_DELAY", 5)
         monkeypatch.setattr(ci, "CI_SETTLE_CHECKS", 1)
         with patch("improve.ci.get_latest_run_id", return_value=200):
             result = ci._wait_for_new_run("feature", 100)
@@ -145,15 +171,15 @@ class TestWaitForNewRun:
         assert result == 200
 
     def test_returns_none_when_no_new_run_appears(self, monkeypatch):
-        monkeypatch.setattr(ci, "CI_APPEAR_TIMEOUT", 0.01)
-        monkeypatch.setattr(ci, "CI_POLL_INTERVAL", 0.001)
+        monkeypatch.setattr(ci, "CI_APPEAR_TIMEOUT", 30)
+        monkeypatch.setattr(ci, "CI_POLL_INTERVAL", 10)
         with patch("improve.ci.get_latest_run_id", return_value=100):
             result = ci._wait_for_new_run("feature", 100)
 
         assert result is None
 
     def test_settles_on_latest_run_when_ids_keep_changing(self, monkeypatch):
-        monkeypatch.setattr(ci, "CI_SETTLE_DELAY", 0)
+        monkeypatch.setattr(ci, "CI_SETTLE_DELAY", 5)
         monkeypatch.setattr(ci, "CI_SETTLE_CHECKS", 3)
         with patch("improve.ci.get_latest_run_id", side_effect=[200, 300, 400, 400]):
             result = ci._wait_for_new_run("feature", 100)
@@ -161,8 +187,8 @@ class TestWaitForNewRun:
         assert result == 400
 
     def test_skips_none_results_during_polling(self, monkeypatch):
-        monkeypatch.setattr(ci, "CI_POLL_INTERVAL", 0)
-        monkeypatch.setattr(ci, "CI_SETTLE_DELAY", 0)
+        monkeypatch.setattr(ci, "CI_POLL_INTERVAL", 10)
+        monkeypatch.setattr(ci, "CI_SETTLE_DELAY", 5)
         monkeypatch.setattr(ci, "CI_SETTLE_CHECKS", 1)
         with patch("improve.ci.get_latest_run_id", side_effect=[None, None, 200, 200]):
             result = ci._wait_for_new_run("feature", 100)

--- a/tests/test_ci_gh.py
+++ b/tests/test_ci_gh.py
@@ -55,3 +55,31 @@ class TestGitHubCI:
     def test_get_failed_logs_returns_fallback_when_empty(self, provider):
         with patch("improve.ci_gh.run", return_value=_cp(stdout="")):
             assert provider.get_failed_logs(42) == "No logs available"
+
+    def test_get_latest_run_id_passes_workflow_and_branch(self, provider):
+        with patch("improve.ci_gh.run", return_value=_cp(stdout="[]")) as mock_run:
+            provider.get_latest_run_id("my-branch")
+
+        args = mock_run.call_args[0][0]
+        assert "--workflow" in args
+        assert "my-branch" in args
+
+    def test_get_run_conclusion_passes_run_id_in_command(self, provider):
+        with patch("improve.ci_gh.run", return_value=_cp(stdout='{"conclusion": "success"}')) as m:
+            provider.get_run_conclusion(99)
+
+        assert "99" in m.call_args[0][0]
+
+    def test_get_run_conclusion_returns_none_on_non_dict_json(self, provider):
+        with patch("improve.ci_gh.run", return_value=_cp(stdout="[1,2]")):
+            assert provider.get_run_conclusion(42) is None
+
+    def test_get_failed_logs_passes_timeout(self, provider):
+        with patch("improve.ci_gh.run", return_value=_cp(stdout="log output")) as mock_run:
+            provider.get_failed_logs(42)
+
+        assert mock_run.call_args[1].get("timeout") == 60
+
+    def test_get_failed_logs_returns_fallback_on_command_failure(self, provider):
+        with patch("improve.ci_gh.run", return_value=_cp(returncode=1)):
+            assert provider.get_failed_logs(42) == "No logs available"

--- a/tests/test_ci_gh.py
+++ b/tests/test_ci_gh.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 import pytest
 
-from improve.ci import CIProvider
 from improve.ci_gh import GitHubCI
 from tests import _cp
 
@@ -13,10 +12,6 @@ def provider():
 
 
 class TestGitHubCI:
-    def test_satisfies_ci_provider_protocol(self, provider):
-        typed: CIProvider = provider
-        assert isinstance(typed, GitHubCI)
-
     def test_get_latest_run_id_parses_database_id(self, provider):
         with patch("improve.ci_gh.run", return_value=_cp(stdout='[{"databaseId": 99}]')):
             assert provider.get_latest_run_id("main") == 99

--- a/tests/test_ci_glab.py
+++ b/tests/test_ci_glab.py
@@ -92,16 +92,24 @@ class TestWatchRun:
         with patch.object(provider, "get_run_conclusion", return_value=conclusion):
             assert provider.watch_run(1, timeout=60) is expected
 
-    def test_returns_false_on_timeout(self, provider, monkeypatch):
-        monkeypatch.setattr("improve.ci_glab.POLL_INTERVAL", 0.001)
-        with patch.object(provider, "get_run_conclusion", return_value=None):
-            assert provider.watch_run(1, timeout=0) is False
+    def test_returns_false_on_timeout(self, provider):
+        clock = iter([0.0, 61.0])
+        with (
+            patch("improve.ci_glab.time.monotonic", side_effect=lambda: next(clock)),
+            patch("improve.ci_glab.time.sleep"),
+            patch.object(provider, "get_run_conclusion", return_value=None),
+        ):
+            assert provider.watch_run(1, timeout=60) is False
 
-    def test_polls_until_conclusion_reached(self, provider, monkeypatch):
-        monkeypatch.setattr("improve.ci_glab.POLL_INTERVAL", 0.001)
-        with patch.object(
-            provider, "get_run_conclusion", side_effect=[None, None, "success"]
-        ) as mock_conclusion:
+    def test_polls_until_conclusion_reached(self, provider):
+        clock = iter([0.0, 10.0, 20.0, 30.0])
+        with (
+            patch("improve.ci_glab.time.monotonic", side_effect=lambda: next(clock)),
+            patch("improve.ci_glab.time.sleep"),
+            patch.object(
+                provider, "get_run_conclusion", side_effect=[None, None, "success"]
+            ) as mock_conclusion,
+        ):
             result = provider.watch_run(1, timeout=60)
 
         assert result is True

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -57,20 +57,6 @@ class TestWrap:
         assert result == f"{color.RED}hello{color.RESET}"
 
 
-class TestPhaseColor:
-    def test_returns_dark_green_for_simplify(self):
-        assert color.phase_color("simplify") == color.DARK_GREEN
-
-    def test_returns_dark_yellow_for_review(self):
-        assert color.phase_color("review") == color.DARK_YELLOW
-
-    def test_returns_dark_red_for_security(self):
-        assert color.phase_color("security") == color.DARK_RED
-
-    def test_returns_empty_string_for_unknown_phase(self):
-        assert color.phase_color("unknown") == ""
-
-
 class TestStatusMark:
     def test_shows_check_mark_for_passed_with_changes(self):
         color.enabled = False

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -27,6 +27,16 @@ class TestHeadSha:
         assert "Failed to determine HEAD sha" in caplog.text
 
 
+class TestHeadShaEdgeCases:
+    def test_returns_empty_when_command_succeeds_with_empty_output(self):
+        with patch("improve.git.run", return_value=_cp(stdout="")):
+            assert git.head_sha() == ""
+
+    def test_returns_sha_when_command_succeeds(self):
+        with patch("improve.git.run", return_value=_cp(stdout="abc123\n")):
+            assert git.head_sha() == "abc123"
+
+
 class TestRevertTo:
     def test_returns_true_on_successful_reset_and_push(self):
         with patch("improve.git.run") as mock_run:
@@ -121,6 +131,12 @@ class TestDetectPlatform:
     def test_defaults_to_github_when_remote_fails(self):
         with patch("improve.git.run", return_value=_cp(returncode=1)):
             assert git.detect_platform() == "github"
+
+    def test_passes_correct_command_to_git(self):
+        with patch("improve.git.run", return_value=_cp(stdout="https://github.com/u/r\n")) as m:
+            git.detect_platform()
+
+        m.assert_called_once_with(["git", "remote", "get-url", "origin"])
 
 
 class TestHasChanges:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -43,6 +44,35 @@ class TestRevertTo:
         with patch("improve.git.run") as mock_run:
             mock_run.side_effect = [_cp(), _cp(returncode=1, stderr="rejected")]
             assert git.revert_to("abc123", "feature") is False
+
+    def test_logs_truncated_sha_on_success(self, caplog):
+        with (
+            patch("improve.git.run") as mock_run,
+            caplog.at_level(logging.INFO, logger="improve"),
+        ):
+            mock_run.side_effect = [_cp(), _cp()]
+            git.revert_to("abc12345xyz", "feature")
+
+        assert "abc12345" in caplog.text
+
+    def test_logs_reset_failed_warning(self, caplog):
+        with (
+            patch("improve.git.run", return_value=_cp(returncode=1, stderr="oops")),
+            caplog.at_level(logging.WARNING, logger="improve"),
+        ):
+            git.revert_to("abc123", "feature")
+
+        assert "Reset failed" in caplog.text
+
+    def test_logs_push_failed_warning(self, caplog):
+        with (
+            patch("improve.git.run") as mock_run,
+            caplog.at_level(logging.WARNING, logger="improve"),
+        ):
+            mock_run.side_effect = [_cp(), _cp(returncode=1, stderr="rejected")]
+            git.revert_to("abc123", "feature")
+
+        assert "Force push failed" in caplog.text
 
 
 class TestDiscardChanges:
@@ -204,6 +234,27 @@ class TestCommitAndPush:
         ):
             mock_run.side_effect = [_cp(), _cp(returncode=1, stderr="rejected")]
             assert git.commit_and_push("Fix bug", "feature") is False
+
+    def test_logs_pushed_message_on_success(self, caplog):
+        with (
+            patch("improve.git.stage_tracked_changes"),
+            patch("improve.git.run") as mock_run,
+            caplog.at_level(logging.INFO, logger="improve"),
+        ):
+            mock_run.side_effect = [_cp(), _cp()]
+            git.commit_and_push("Fix bug", "feature")
+
+        assert "Pushed:" in caplog.text
+
+    def test_logs_commit_failed_warning(self, caplog):
+        with (
+            patch("improve.git.stage_tracked_changes"),
+            patch("improve.git.run", return_value=_cp(returncode=1, stderr="err")),
+            caplog.at_level(logging.WARNING, logger="improve"),
+        ):
+            git.commit_and_push("Fix bug", "feature")
+
+        assert "Commit failed" in caplog.text
 
 
 class TestSyncWithMain:
@@ -601,3 +652,40 @@ class TestSquashBranch:
             result = git.squash_branch("feature", "Squashed")
 
         assert result is False
+
+    def test_returns_true_when_zero_commits(self):
+        with patch("improve.git.run") as mock_run:
+            mock_run.side_effect = [
+                _cp(stdout="abc123\n"),
+                _cp(stdout="0\n"),
+            ]
+            assert git.squash_branch("feature", "Squashed") is True
+
+    def test_logs_nothing_to_squash_for_one_commit(self, caplog):
+        with (
+            patch("improve.git.run") as mock_run,
+            caplog.at_level(logging.INFO, logger="improve"),
+        ):
+            mock_run.side_effect = [
+                _cp(stdout="abc123\n"),
+                _cp(stdout="1\n"),
+            ]
+            git.squash_branch("feature", "Squashed")
+
+        assert "Nothing to squash" in caplog.text
+
+    def test_logs_success_message_after_squash(self, caplog):
+        with (
+            patch("improve.git.run") as mock_run,
+            caplog.at_level(logging.INFO, logger="improve"),
+        ):
+            mock_run.side_effect = [
+                _cp(stdout="abc123\n"),
+                _cp(stdout="3\n"),
+                _cp(),
+                _cp(),
+                _cp(),
+            ]
+            git.squash_branch("feature", "Squashed")
+
+        assert "Squashed and force-pushed" in caplog.text

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -2,7 +2,6 @@ import pytest
 
 from improve.phases import (
     AVAILABLE_PHASES,
-    PHASE_COMMIT_PREFIX,
     _truncate,
     build_ci_fix_prompt,
     build_commit_message,
@@ -52,11 +51,6 @@ class TestBuildCommitMessage:
         )
 
         assert len(result) <= 50
-
-
-class TestAvailablePhases:
-    def test_contains_all_expected_phases(self):
-        assert set(AVAILABLE_PHASES) == {"simplify", "review", "security"}
 
 
 class TestStripCodeFences:
@@ -186,17 +180,6 @@ class TestBuildCommitMessageEdgeCases:
         result = build_commit_message("unknown_phase", "something")
 
         assert result.startswith("Fix")
-
-
-class TestPhaseCommitPrefix:
-    def test_simplify_prefix_is_simplify(self):
-        assert PHASE_COMMIT_PREFIX["simplify"] == "Simplify"
-
-    def test_review_prefix_is_fix(self):
-        assert PHASE_COMMIT_PREFIX["review"] == "Fix"
-
-    def test_security_prefix_is_fix(self):
-        assert PHASE_COMMIT_PREFIX["security"] == "Fix"
 
 
 class TestExtractSummaryBoundary:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,10 +3,9 @@ from unittest.mock import patch
 
 import pytest
 
-from improve import color
 from improve.phases import AVAILABLE_PHASES
 from improve.runner import MAX_CI_RETRIES, IterationLoop
-from improve.state import LoopState, PhaseResult, format_summary
+from improve.state import LoopState, PhaseResult
 
 
 def _make_loop(
@@ -260,26 +259,6 @@ class TestRunPhase:
             result = loop.run_phase("security", 1, skip_ci=True)
 
         assert result.phase == "security"
-
-
-class TestFormatSummaryIntegration:
-    def test_formats_results_with_phase_details(self, tmp_path, monkeypatch):
-        loop = _make_loop(tmp_path, monkeypatch)
-        loop.state.add(
-            PhaseResult(1, "simplify", True, ["a.py"], "Extracted helper", True, 0, 10.0, 8.0, 2.0)
-        )
-
-        output = format_summary(loop.state.results, 15.0)
-
-        assert "Results" in output
-        assert "Extracted helper" in output
-
-    def test_formats_empty_summary_when_no_phases_ran(self, tmp_path, monkeypatch):
-        loop = _make_loop(tmp_path, monkeypatch)
-
-        output = format_summary(loop.state.results, 0.0)
-
-        assert "Phases run:     0" in output
 
 
 class TestRunBatchIteration:
@@ -801,16 +780,3 @@ class TestContinuousMode:
 
         output = capsys.readouterr().out
         assert "Iteration 1/5" in output
-
-
-class TestFormatSummaryReverted:
-    def test_shows_reverted_status_for_reverted_phases(self, tmp_path, monkeypatch):
-        color.enabled = False
-        loop = _make_loop(tmp_path, monkeypatch)
-        result = PhaseResult(1, "simplify", True, ["a.py"], "Stuff", False, 1, reverted=True)
-        loop.state.add(result)
-
-        output = format_summary(loop.state.results, 10.0)
-
-        assert "REVT" in output
-        assert "Reverted:       1" in output

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -102,28 +102,59 @@ class TestRetryCiFixes:
         assert claude_time == 1.5
         assert ci_time == 3.0
 
-    def test_stops_when_no_changes_produced(self, tmp_path, monkeypatch):
+    def test_stops_when_no_changes_produced(self, tmp_path, monkeypatch, caplog):
         loop = _make_loop(tmp_path, monkeypatch)
         with (
             patch("improve.claude.run_claude", return_value=("", 1.0)),
             patch("improve.git.has_changes", return_value=False),
+            caplog.at_level(logging.INFO, logger="improve"),
         ):
             passed, retries, _, _ = loop.retry_ci_fixes(False, "err", "Fix")
 
         assert passed is False
         assert retries == 1
+        assert "No fix produced" in caplog.text
 
-    def test_stops_when_push_fails(self, tmp_path, monkeypatch):
+    def test_stops_when_push_fails(self, tmp_path, monkeypatch, caplog):
         loop = _make_loop(tmp_path, monkeypatch)
         with (
             patch("improve.claude.run_claude", return_value=("", 1.0)),
             patch("improve.git.has_changes", return_value=True),
             patch("improve.git.commit_and_push", return_value=False),
+            caplog.at_level(logging.WARNING, logger="improve"),
         ):
             passed, retries, _, _ = loop.retry_ci_fixes(False, "err", "Fix")
 
         assert passed is False
         assert retries == 1
+        assert "Push failed" in caplog.text
+
+    def test_logs_attempt_number_on_retry(self, tmp_path, monkeypatch, caplog):
+        loop = _make_loop(tmp_path, monkeypatch)
+        with (
+            patch("improve.claude.run_claude", return_value=("output", 1.0)),
+            patch("improve.git.has_changes", return_value=True),
+            patch("improve.ci.get_latest_run_id", return_value=100),
+            patch("improve.git.commit_and_push", return_value=True),
+            patch("improve.ci.wait_for_ci", return_value=(True, "", 1.0)),
+            caplog.at_level(logging.INFO, logger="improve"),
+        ):
+            loop.retry_ci_fixes(False, "err", "Fix")
+
+        assert "Attempt 1/5" in caplog.text
+
+    def test_passes_pre_push_id_to_wait_for_ci(self, tmp_path, monkeypatch):
+        loop = _make_loop(tmp_path, monkeypatch)
+        with (
+            patch("improve.claude.run_claude", return_value=("out", 1.0)),
+            patch("improve.git.has_changes", return_value=True),
+            patch("improve.ci.get_latest_run_id", return_value=42),
+            patch("improve.git.commit_and_push", return_value=True),
+            patch("improve.ci.wait_for_ci", return_value=(True, "", 1.0)) as mock_wait,
+        ):
+            loop.retry_ci_fixes(False, "err", "Fix")
+
+        mock_wait.assert_called_once_with("feature", known_previous_id=42)
 
     def test_exhausts_all_retry_attempts(self, tmp_path, monkeypatch):
         loop = _make_loop(tmp_path, monkeypatch)


### PR DESCRIPTION
## Summary
- Fix release workflow referencing `src/` instead of `improve/` (broke after #27 restructure)
- Randomize mutmut source file order in CI — each run shuffles files so different code gets covered first within the 5-minute timeout
- Add nightly full mutation testing workflow (3h timeout, runs at 2:00 AM UTC, also manually triggerable)
- Remove 12 tests that verified constants or duplicated coverage from other test files
- Mock `time.monotonic` in CI timing tests to eliminate flakiness
- Add 25+ tests for log message assertions, boundary conditions, and command argument verification to improve mutation kill rate (57.8% → 66.7%)

## Test plan
- [x] Release workflow passes ruff check/format with `improve/` paths
- [x] CI mutation job passes with randomized file order
- [x] All 556 tests pass locally
- [x] Mutation kill rate above 60% threshold in CI