### PR TITLE
Exclude .improve-loop from staged changes

### DIFF
--- a/improve/git.py
+++ b/improve/git.py
@@ -53,7 +53,7 @@ def detect_platform() -> str:
 
 
 def has_changes() -> bool:
-    return bool(run(["git", "status", "--porcelain", "--no-renames"]).stdout.strip())
+    return bool(changed_files())
 
 
 def changed_files(cwd: str | None = None) -> list[str]:
@@ -62,7 +62,8 @@ def changed_files(cwd: str | None = None) -> list[str]:
         cmd.extend(["-C", cwd])
     cmd.extend(["status", "--porcelain", "--no-renames"])
     lines = run(cmd).stdout.split("\n")
-    return [line[3:].strip() for line in lines if line.strip()]
+    paths = (line[3:].strip() for line in lines if line.strip())
+    return [p for p in paths if not p.startswith(".improve-loop/")]
 
 
 def diff_vs_main() -> str:
@@ -244,7 +245,7 @@ def apply_worktree_changes(worktree_path: str) -> list[str]:
 
 
 def squash_branch(branch_name: str, message: str) -> bool:
-    base = run(["git", "merge-base", "HEAD", "main"]).stdout.strip()
+    base = run(["git", "merge-base", "HEAD", "origin/main"]).stdout.strip()
     if not base:
         logger.warning("git] Cannot find merge base with main")
         return False

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -150,6 +150,10 @@ class TestHasChanges:
         with patch("improve.git.run", return_value=_cp(stdout="")):
             assert git.has_changes() is False
 
+    def test_returns_false_when_only_improve_loop_files_changed(self):
+        with patch("improve.git.run", return_value=_cp(stdout=" M .improve-loop/state.json\n")):
+            assert git.has_changes() is False
+
 
 class TestChangedFiles:
     def test_extracts_filenames_from_porcelain_output(self):
@@ -162,6 +166,16 @@ class TestChangedFiles:
 
     def test_returns_empty_list_when_no_changes(self):
         with patch("improve.git.run", return_value=_cp(stdout="")):
+            assert git.changed_files() == []
+
+    def test_excludes_improve_loop_directory_files(self):
+        result = _cp(stdout=" M src/a.py\n M .improve-loop/state.json\n?? .improve-loop/run.log\n")
+        with patch("improve.git.run", return_value=result):
+            assert git.changed_files() == ["src/a.py"]
+
+    def test_returns_empty_when_only_improve_loop_files_changed(self):
+        result = _cp(stdout=" M .improve-loop/state.json\n")
+        with patch("improve.git.run", return_value=result):
             assert git.changed_files() == []
 
 
@@ -615,7 +629,7 @@ class TestSquashBranch:
             ]
             assert git.squash_branch("feature", "Squashed") is True
 
-        mock_run.assert_any_call(["git", "merge-base", "HEAD", "main"])
+        mock_run.assert_any_call(["git", "merge-base", "HEAD", "origin/main"])
         mock_run.assert_any_call(["git", "rev-list", "--count", "abc123..HEAD"])
         mock_run.assert_any_call(["git", "reset", "--soft", "abc123"])
         mock_run.assert_any_call(["git", "commit", "-m", "Squashed"])

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "iterative-improve"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Filter `.improve-loop/` paths from `changed_files()` so the tool never stages or commits its own state files
- Make `has_changes()` delegate to `changed_files()` for consistent filtering
- Fix `squash_branch()` using stale local `main` instead of `origin/main` for merge-base

## Test plan
- [x] All 556 existing tests pass