### PR TITLE
Retry crashed phases and raise Claude max-turns to 50

### DIFF
--- a/improve/claude.py
+++ b/improve/claude.py
@@ -181,7 +181,7 @@ def _start_claude(prompt: str, cwd: str | None) -> subprocess.Popen:
             "--effort",
             "max",
             "--max-turns",
-            "25",
+            "50",
         ],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,

--- a/improve/parallel.py
+++ b/improve/parallel.py
@@ -185,7 +185,7 @@ def run_parallel_batch(
             add_result(result)
 
         if not any(r.changes_made for r in results):
-            crashed = [r.phase for r in results if r.summary == "Phase crashed"]
+            crashed = [r.phase for r in results if r.is_crashed()]
             if crashed:
                 logger.info(
                     "loop] Retrying crashed phase(s) next iteration: %s", ", ".join(crashed)

--- a/improve/parallel.py
+++ b/improve/parallel.py
@@ -185,6 +185,12 @@ def run_parallel_batch(
             add_result(result)
 
         if not any(r.changes_made for r in results):
+            crashed = [r.phase for r in results if r.summary == "Phase crashed"]
+            if crashed:
+                logger.info(
+                    "loop] Retrying crashed phase(s) next iteration: %s", ", ".join(crashed)
+                )
+                return True
             logger.info("loop] Converged: no changes in any phase")
             return False
 

--- a/improve/parallel.py
+++ b/improve/parallel.py
@@ -185,7 +185,7 @@ def run_parallel_batch(
             add_result(result)
 
         if not any(r.changes_made for r in results):
-            crashed = [r.phase for r in results if r.is_crashed()]
+            crashed = [r.phase for r in results if r.is_crashed]
             if crashed:
                 logger.info(
                     "loop] Retrying crashed phase(s) next iteration: %s", ", ".join(crashed)

--- a/improve/runner.py
+++ b/improve/runner.py
@@ -153,7 +153,7 @@ class IterationLoop:
             return PhaseResult.crashed(iteration, phase)
 
     def _drop_converged_phases(self, results: list[PhaseResult]) -> None:
-        converged = {r.phase for r in results if not r.changes_made and not r.is_crashed()}
+        converged = {r.phase for r in results if not r.changes_made and not r.is_crashed}
         if not converged:
             return
         self._active_phases = [p for p in self._active_phases if p not in converged]
@@ -167,7 +167,7 @@ class IterationLoop:
         self._drop_converged_phases(results)
         if any(r.changes_made for r in results):
             return False
-        crashed = [r.phase for r in results if r.is_crashed()]
+        crashed = [r.phase for r in results if r.is_crashed]
         if crashed:
             logger.info("loop] Retrying crashed phase(s) next iteration: %s", ", ".join(crashed))
             return False

--- a/improve/runner.py
+++ b/improve/runner.py
@@ -153,9 +153,7 @@ class IterationLoop:
             return PhaseResult.crashed(iteration, phase)
 
     def _drop_converged_phases(self, results: list[PhaseResult]) -> None:
-        converged = {
-            r.phase for r in results if not r.changes_made and r.summary != "Phase crashed"
-        }
+        converged = {r.phase for r in results if not r.changes_made and not r.is_crashed()}
         if not converged:
             return
         self._active_phases = [p for p in self._active_phases if p not in converged]
@@ -169,7 +167,7 @@ class IterationLoop:
         self._drop_converged_phases(results)
         if any(r.changes_made for r in results):
             return False
-        crashed = [r.phase for r in results if r.summary == "Phase crashed"]
+        crashed = [r.phase for r in results if r.is_crashed()]
         if crashed:
             logger.info("loop] Retrying crashed phase(s) next iteration: %s", ", ".join(crashed))
             return False

--- a/improve/runner.py
+++ b/improve/runner.py
@@ -167,10 +167,14 @@ class IterationLoop:
 
     def _check_convergence(self, results: list[PhaseResult]) -> bool:
         self._drop_converged_phases(results)
-        if not any(r.changes_made for r in results):
-            logger.info("loop] Converged: no changes in any phase")
-            return True
-        return False
+        if any(r.changes_made for r in results):
+            return False
+        crashed = [r.phase for r in results if r.summary == "Phase crashed"]
+        if crashed:
+            logger.info("loop] Retrying crashed phase(s) next iteration: %s", ", ".join(crashed))
+            return False
+        logger.info("loop] Converged: no changes in any phase")
+        return True
 
     def run_batch_iteration(self, iteration: int) -> bool:
         pre_batch_run_id = (

--- a/improve/state.py
+++ b/improve/state.py
@@ -66,6 +66,9 @@ class PhaseResult:
             ci_retries=0,
         )
 
+    def is_crashed(self) -> bool:
+        return self.summary == "Phase crashed"
+
 
 @dataclass
 class LoopState:

--- a/improve/state.py
+++ b/improve/state.py
@@ -66,6 +66,7 @@ class PhaseResult:
             ci_retries=0,
         )
 
+    @property
     def is_crashed(self) -> bool:
         return self.summary == "Phase crashed"
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -100,6 +100,32 @@ class TestRunParallelBatch:
 
         assert result is False
 
+    def test_returns_true_when_a_phase_crashed_so_loop_retries_next_iteration(self):
+        results = [
+            PhaseResult.crashed(1, "simplify"),
+            PhaseResult(1, "review", False, [], "No changes needed", True, 0),
+        ]
+
+        with (
+            patch("improve.parallel.git.diff_vs_main", return_value="file.py"),
+            patch("improve.parallel.git.create_worktree", return_value=True),
+            patch("improve.parallel.git.remove_worktree"),
+            patch("improve.parallel.run_phase_in_worktree", side_effect=results),
+            patch("tempfile.mkdtemp", return_value="/tmp/improve-test"),
+        ):
+            result = run_parallel_batch(
+                ["simplify", "review"],
+                1,
+                "feature",
+                "None",
+                True,
+                MagicMock(),
+                MagicMock(),
+                _test_config(),
+            )
+
+        assert result is True
+
     def test_applies_changes_and_commits(self):
         changed = PhaseResult(1, "simplify", True, ["a.py"], "Fixed stuff", True, 0)
         add_result = MagicMock()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1040,3 +1040,33 @@ class TestCheckConvergence:
 
         assert "simplify" not in loop._active_phases
         assert "review" in loop._active_phases
+
+    def test_returns_false_when_a_phase_crashed_even_if_no_changes(self, tmp_path, monkeypatch):
+        loop = _make_loop(tmp_path, monkeypatch, phases=["simplify", "review"])
+        results = [
+            PhaseResult.crashed(1, "simplify"),
+            PhaseResult(1, "review", False, [], "No changes needed", True, 0),
+        ]
+
+        assert loop._check_convergence(results) is False
+
+    def test_keeps_crashed_phase_active_for_retry(self, tmp_path, monkeypatch):
+        loop = _make_loop(tmp_path, monkeypatch, phases=["simplify", "review"])
+        results = [
+            PhaseResult.crashed(1, "simplify"),
+            PhaseResult(1, "review", False, [], "No changes needed", True, 0),
+        ]
+
+        loop._check_convergence(results)
+
+        assert loop._active_phases == ["simplify"]
+
+    def test_logs_retry_message_when_phase_crashed(self, tmp_path, monkeypatch, caplog):
+        loop = _make_loop(tmp_path, monkeypatch, phases=["simplify"])
+        results = [PhaseResult.crashed(1, "simplify")]
+
+        with caplog.at_level(logging.INFO, logger="improve"):
+            loop._check_convergence(results)
+
+        assert "Retrying crashed phase(s) next iteration" in caplog.text
+        assert "simplify" in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "iterative-improve"
-version = "0.2.18"
+version = "0.2.19"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Loop no longer stops when a phase crashes — convergence is now distinguished from a crash, and crashed phases retry in the next iteration (while converged phases are still dropped).
- Bump Claude `--max-turns` from 25 to 50 so complex write→test→fix phases have headroom to finish.

## Why
Running `iterative-improve --parallel` on a real branch, the simplify phase hit Claude CLI's `--max-turns 25` mid-task (during a gradle test verify loop) and exited with code 1. `_drop_converged_phases` correctly kept `simplify` in `_active_phases`, but the outer check `not any(r.changes_made for r in results)` treated the crash as convergence and broke the loop. Result: `Dropping converged phase(s): review, security — remaining: simplify` followed immediately by `Finished` with no retry.

## Test plan
- [x] `uv run pytest -q` — 835 passed
- [x] `uv run ruff check improve/ tests/`
- [x] `uv run ruff format --check improve/ tests/`
- [x] New tests: `_check_convergence` returns False when a phase crashed; `run_parallel_batch` returns True (continue) when a phase crashed; log message verified.